### PR TITLE
geom_alt props

### DIFF
--- a/data/421/166/707/421166707.geojson
+++ b/data/421/166/707/421166707.geojson
@@ -193,6 +193,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459008700,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"955ed688d0fb1a9b3a6aa26dc561734d",
     "wof:hierarchy":[
         {
@@ -203,7 +206,7 @@
         }
     ],
     "wof:id":421166707,
-    "wof:lastmodified":1566651020,
+    "wof:lastmodified":1582345121,
     "wof:name":"Santa Ana",
     "wof:parent_id":85677195,
     "wof:placetype":"county",

--- a/data/421/167/823/421167823.geojson
+++ b/data/421/167/823/421167823.geojson
@@ -110,6 +110,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459008744,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4f220e2107cdd9767c33db22754e13a2",
     "wof:hierarchy":[
         {
@@ -120,7 +123,7 @@
         }
     ],
     "wof:id":421167823,
-    "wof:lastmodified":1566651025,
+    "wof:lastmodified":1582345121,
     "wof:name":"Juayua",
     "wof:parent_id":85677159,
     "wof:placetype":"county",

--- a/data/421/168/319/421168319.geojson
+++ b/data/421/168/319/421168319.geojson
@@ -110,6 +110,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459008761,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"df978238bd28774482551c9dbddf0f13",
     "wof:hierarchy":[
         {
@@ -120,7 +123,7 @@
         }
     ],
     "wof:id":421168319,
-    "wof:lastmodified":1566651020,
+    "wof:lastmodified":1582345121,
     "wof:name":"Jiquilisco",
     "wof:parent_id":85677187,
     "wof:placetype":"county",

--- a/data/421/169/323/421169323.geojson
+++ b/data/421/169/323/421169323.geojson
@@ -109,6 +109,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459008804,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4d6eeb7f0fb7e17d463cf7973b4a5e3d",
     "wof:hierarchy":[
         {
@@ -119,7 +122,7 @@
         }
     ],
     "wof:id":421169323,
-    "wof:lastmodified":1566651026,
+    "wof:lastmodified":1582345121,
     "wof:name":"Ahuachapan",
     "wof:parent_id":85677139,
     "wof:placetype":"county",

--- a/data/421/169/439/421169439.geojson
+++ b/data/421/169/439/421169439.geojson
@@ -122,6 +122,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459008810,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"feaa2b4652e13deb451ef9f8322542d0",
     "wof:hierarchy":[
         {
@@ -132,7 +135,7 @@
         }
     ],
     "wof:id":421169439,
-    "wof:lastmodified":1566651026,
+    "wof:lastmodified":1582345121,
     "wof:name":"Izalco",
     "wof:parent_id":85677159,
     "wof:placetype":"county",

--- a/data/421/170/965/421170965.geojson
+++ b/data/421/170/965/421170965.geojson
@@ -113,6 +113,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459008876,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9409ca81fa47c2119667de2b1600c388",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
         }
     ],
     "wof:id":421170965,
-    "wof:lastmodified":1566651050,
+    "wof:lastmodified":1582345124,
     "wof:name":"San Juan Nonualco",
     "wof:parent_id":85677155,
     "wof:placetype":"county",

--- a/data/421/171/699/421171699.geojson
+++ b/data/421/171/699/421171699.geojson
@@ -107,6 +107,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459008904,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3f8c1203d79a5680486f16bbb4a3d13f",
     "wof:hierarchy":[
         {
@@ -117,7 +120,7 @@
         }
     ],
     "wof:id":421171699,
-    "wof:lastmodified":1566651059,
+    "wof:lastmodified":1582345124,
     "wof:name":"Chiltiupan",
     "wof:parent_id":85677151,
     "wof:placetype":"county",

--- a/data/421/171/701/421171701.geojson
+++ b/data/421/171/701/421171701.geojson
@@ -101,6 +101,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459008904,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0dd2c506745c46bdc11841a6d427f076",
     "wof:hierarchy":[
         {
@@ -111,7 +114,7 @@
         }
     ],
     "wof:id":421171701,
-    "wof:lastmodified":1566651059,
+    "wof:lastmodified":1582345124,
     "wof:name":"Jicalapa",
     "wof:parent_id":85677151,
     "wof:placetype":"county",

--- a/data/421/171/703/421171703.geojson
+++ b/data/421/171/703/421171703.geojson
@@ -103,6 +103,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459008904,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fb3d6170ae8263f7551ecea6e2d2f880",
     "wof:hierarchy":[
         {
@@ -113,7 +116,7 @@
         }
     ],
     "wof:id":421171703,
-    "wof:lastmodified":1566651059,
+    "wof:lastmodified":1582345124,
     "wof:name":"Quezaltepeque",
     "wof:parent_id":85677151,
     "wof:placetype":"county",

--- a/data/421/171/705/421171705.geojson
+++ b/data/421/171/705/421171705.geojson
@@ -95,6 +95,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459008904,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"895be36f1d9eb22ae151c9416afcd750",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":421171705,
-    "wof:lastmodified":1566651059,
+    "wof:lastmodified":1582345124,
     "wof:name":"San Matias",
     "wof:parent_id":85677151,
     "wof:placetype":"county",

--- a/data/421/171/709/421171709.geojson
+++ b/data/421/171/709/421171709.geojson
@@ -122,6 +122,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459008904,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f96bc8b965221884688864874b56d1b9",
     "wof:hierarchy":[
         {
@@ -132,7 +135,7 @@
         }
     ],
     "wof:id":421171709,
-    "wof:lastmodified":1566651059,
+    "wof:lastmodified":1582345124,
     "wof:name":"Metapan",
     "wof:parent_id":85677195,
     "wof:placetype":"county",

--- a/data/421/172/529/421172529.geojson
+++ b/data/421/172/529/421172529.geojson
@@ -121,6 +121,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459008946,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"21694d81d035eb07c58c3682a16f31b2",
     "wof:hierarchy":[
         {
@@ -131,7 +134,7 @@
         }
     ],
     "wof:id":421172529,
-    "wof:lastmodified":1566651036,
+    "wof:lastmodified":1582345123,
     "wof:name":"El Carmen",
     "wof:parent_id":85677145,
     "wof:placetype":"county",

--- a/data/421/172/531/421172531.geojson
+++ b/data/421/172/531/421172531.geojson
@@ -185,6 +185,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459008946,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"555328cdc7f8e671c908f9422cebb566",
     "wof:hierarchy":[
         {
@@ -195,7 +198,7 @@
         }
     ],
     "wof:id":421172531,
-    "wof:lastmodified":1566651036,
+    "wof:lastmodified":1582345123,
     "wof:name":"Intipuca",
     "wof:parent_id":85677169,
     "wof:placetype":"county",

--- a/data/421/172/669/421172669.geojson
+++ b/data/421/172/669/421172669.geojson
@@ -188,6 +188,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459008950,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1282c10c4c72d7c1aea58bd8c082a252",
     "wof:hierarchy":[
         {
@@ -198,7 +201,7 @@
         }
     ],
     "wof:id":421172669,
-    "wof:lastmodified":1566651036,
+    "wof:lastmodified":1582345122,
     "wof:name":"Cojutepeque",
     "wof:parent_id":85677145,
     "wof:placetype":"county",

--- a/data/421/172/671/421172671.geojson
+++ b/data/421/172/671/421172671.geojson
@@ -112,6 +112,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459008950,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cc528e21474a24eda27025d914dbfe64",
     "wof:hierarchy":[
         {
@@ -122,7 +125,7 @@
         }
     ],
     "wof:id":421172671,
-    "wof:lastmodified":1566651037,
+    "wof:lastmodified":1582345123,
     "wof:name":"Corinto",
     "wof:parent_id":85677173,
     "wof:placetype":"county",

--- a/data/421/175/389/421175389.geojson
+++ b/data/421/175/389/421175389.geojson
@@ -234,6 +234,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459009065,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0d94c70e3c76c4beb69145d83f84b1e6",
     "wof:hierarchy":[
         {
@@ -244,7 +247,7 @@
         }
     ],
     "wof:id":421175389,
-    "wof:lastmodified":1566651040,
+    "wof:lastmodified":1582345123,
     "wof:name":"La Palma",
     "wof:parent_id":85677193,
     "wof:placetype":"county",

--- a/data/421/175/391/421175391.geojson
+++ b/data/421/175/391/421175391.geojson
@@ -114,6 +114,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459009065,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f7b451f8b4ad435e83b9676b3bbe8d79",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":421175391,
-    "wof:lastmodified":1566651040,
+    "wof:lastmodified":1582345123,
     "wof:name":"Suchitoto",
     "wof:parent_id":85677145,
     "wof:placetype":"county",

--- a/data/421/176/713/421176713.geojson
+++ b/data/421/176/713/421176713.geojson
@@ -107,6 +107,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459009117,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bac5fd3404c325f342877c1a8791a082",
     "wof:hierarchy":[
         {
@@ -117,7 +120,7 @@
         }
     ],
     "wof:id":421176713,
-    "wof:lastmodified":1566651058,
+    "wof:lastmodified":1582345124,
     "wof:name":"Sesori",
     "wof:parent_id":85677177,
     "wof:placetype":"county",

--- a/data/421/177/967/421177967.geojson
+++ b/data/421/177/967/421177967.geojson
@@ -110,6 +110,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459009166,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"269ce86d3c48306dceb2242c545db127",
     "wof:hierarchy":[
         {
@@ -120,7 +123,7 @@
         }
     ],
     "wof:id":421177967,
-    "wof:lastmodified":1566651051,
+    "wof:lastmodified":1582345124,
     "wof:name":"Nueva Concepcion",
     "wof:parent_id":85677193,
     "wof:placetype":"county",

--- a/data/421/180/175/421180175.geojson
+++ b/data/421/180/175/421180175.geojson
@@ -134,6 +134,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459009247,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9812af304ad4944cbb6677ce39e501ed",
     "wof:hierarchy":[
         {
@@ -144,7 +147,7 @@
         }
     ],
     "wof:id":421180175,
-    "wof:lastmodified":1566651032,
+    "wof:lastmodified":1582345122,
     "wof:name":"Mejicanos",
     "wof:parent_id":85677163,
     "wof:placetype":"county",

--- a/data/421/180/907/421180907.geojson
+++ b/data/421/180/907/421180907.geojson
@@ -393,6 +393,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459009275,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"74d4d2389515d427a09866093241c3b6",
     "wof:hierarchy":[
         {
@@ -403,7 +406,7 @@
         }
     ],
     "wof:id":421180907,
-    "wof:lastmodified":1566651032,
+    "wof:lastmodified":1582345122,
     "wof:name":"San Salvador",
     "wof:parent_id":85677163,
     "wof:placetype":"county",

--- a/data/421/180/913/421180913.geojson
+++ b/data/421/180/913/421180913.geojson
@@ -119,6 +119,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459009275,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"45bb35976956041076e887e041c1c0b9",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":421180913,
-    "wof:lastmodified":1566651032,
+    "wof:lastmodified":1582345122,
     "wof:name":"Ayutuxtepeque",
     "wof:parent_id":85677163,
     "wof:placetype":"county",

--- a/data/421/182/403/421182403.geojson
+++ b/data/421/182/403/421182403.geojson
@@ -276,6 +276,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459009328,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e21f1e766d18a7cb46aa82fc2ce5e6ee",
     "wof:hierarchy":[
         {
@@ -286,7 +289,7 @@
         }
     ],
     "wof:id":421182403,
-    "wof:lastmodified":1566651057,
+    "wof:lastmodified":1582345124,
     "wof:name":"Victoria",
     "wof:parent_id":85677141,
     "wof:placetype":"county",

--- a/data/421/183/079/421183079.geojson
+++ b/data/421/183/079/421183079.geojson
@@ -206,6 +206,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459009357,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"33bca2b54baefa5a2e4fb67b978c4e06",
     "wof:hierarchy":[
         {
@@ -216,7 +219,7 @@
         }
     ],
     "wof:id":421183079,
-    "wof:lastmodified":1566651051,
+    "wof:lastmodified":1582345124,
     "wof:name":"Apopa",
     "wof:parent_id":85677163,
     "wof:placetype":"county",

--- a/data/421/183/081/421183081.geojson
+++ b/data/421/183/081/421183081.geojson
@@ -112,6 +112,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459009357,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4b095cc4872f02404177618534f89db2",
     "wof:hierarchy":[
         {
@@ -122,7 +125,7 @@
         }
     ],
     "wof:id":421183081,
-    "wof:lastmodified":1566651052,
+    "wof:lastmodified":1582345124,
     "wof:name":"Delgado",
     "wof:parent_id":85677163,
     "wof:placetype":"county",

--- a/data/421/183/185/421183185.geojson
+++ b/data/421/183/185/421183185.geojson
@@ -107,6 +107,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459009361,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b29000cf2f2ce50f343212056b96a2a9",
     "wof:hierarchy":[
         {
@@ -117,7 +120,7 @@
         }
     ],
     "wof:id":421183185,
-    "wof:lastmodified":1566651053,
+    "wof:lastmodified":1582345124,
     "wof:name":"Arambala",
     "wof:parent_id":85677173,
     "wof:placetype":"county",

--- a/data/421/184/405/421184405.geojson
+++ b/data/421/184/405/421184405.geojson
@@ -185,6 +185,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459009409,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"43344ef94bee0962edfff9f22fc21450",
     "wof:hierarchy":[
         {
@@ -195,7 +198,7 @@
         }
     ],
     "wof:id":421184405,
-    "wof:lastmodified":1566651049,
+    "wof:lastmodified":1582345124,
     "wof:name":"Ilobasco",
     "wof:parent_id":85677141,
     "wof:placetype":"county",

--- a/data/421/184/407/421184407.geojson
+++ b/data/421/184/407/421184407.geojson
@@ -93,6 +93,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459009409,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"171d13973caea6cf8e503f34bc189994",
     "wof:hierarchy":[
         {
@@ -103,7 +106,7 @@
         }
     ],
     "wof:id":421184407,
-    "wof:lastmodified":1566651049,
+    "wof:lastmodified":1582345124,
     "wof:name":"Estanzuelas",
     "wof:parent_id":85677187,
     "wof:placetype":"county",

--- a/data/421/184/409/421184409.geojson
+++ b/data/421/184/409/421184409.geojson
@@ -185,6 +185,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459009409,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a5469756951b68963596af814ccd440e",
     "wof:hierarchy":[
         {
@@ -195,7 +198,7 @@
         }
     ],
     "wof:id":421184409,
-    "wof:lastmodified":1566651049,
+    "wof:lastmodified":1582345123,
     "wof:name":"Jucuaran",
     "wof:parent_id":85677187,
     "wof:placetype":"county",

--- a/data/421/184/607/421184607.geojson
+++ b/data/421/184/607/421184607.geojson
@@ -185,6 +185,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459009416,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"706f12be34dbd3904cbfcacd6d3e9997",
     "wof:hierarchy":[
         {
@@ -195,7 +198,7 @@
         }
     ],
     "wof:id":421184607,
-    "wof:lastmodified":1566651050,
+    "wof:lastmodified":1582345124,
     "wof:name":"Atiquizaya",
     "wof:parent_id":85677139,
     "wof:placetype":"county",

--- a/data/421/184/721/421184721.geojson
+++ b/data/421/184/721/421184721.geojson
@@ -185,6 +185,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459009420,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8be737f02f38a08403154c428d52cad1",
     "wof:hierarchy":[
         {
@@ -195,7 +198,7 @@
         }
     ],
     "wof:id":421184721,
-    "wof:lastmodified":1566651050,
+    "wof:lastmodified":1582345124,
     "wof:name":"El Transito",
     "wof:parent_id":85677177,
     "wof:placetype":"county",

--- a/data/421/184/831/421184831.geojson
+++ b/data/421/184/831/421184831.geojson
@@ -203,6 +203,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459009423,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"504c2871392cdd9183aac7a51ec3aeb8",
     "wof:hierarchy":[
         {
@@ -213,7 +216,7 @@
         }
     ],
     "wof:id":421184831,
-    "wof:lastmodified":1566651049,
+    "wof:lastmodified":1582345124,
     "wof:name":"Sonsonate",
     "wof:parent_id":85677159,
     "wof:placetype":"county",

--- a/data/421/185/175/421185175.geojson
+++ b/data/421/185/175/421185175.geojson
@@ -107,6 +107,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459009434,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cc3f9c3fba7d0ab31e1045a5209caada",
     "wof:hierarchy":[
         {
@@ -117,7 +120,7 @@
         }
     ],
     "wof:id":421185175,
-    "wof:lastmodified":1566651059,
+    "wof:lastmodified":1582345124,
     "wof:name":"Jocoro",
     "wof:parent_id":85677173,
     "wof:placetype":"county",

--- a/data/421/185/233/421185233.geojson
+++ b/data/421/185/233/421185233.geojson
@@ -104,6 +104,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459009436,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c717e7ad9073176af9d77bf943b97065",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
         }
     ],
     "wof:id":421185233,
-    "wof:lastmodified":1566651059,
+    "wof:lastmodified":1582345124,
     "wof:name":"San Rafael Obrajuelo",
     "wof:parent_id":85677155,
     "wof:placetype":"county",

--- a/data/421/186/439/421186439.geojson
+++ b/data/421/186/439/421186439.geojson
@@ -116,6 +116,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459009481,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8eb9527f8c4bcc7653a3b32417c0a5a5",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":421186439,
-    "wof:lastmodified":1566651038,
+    "wof:lastmodified":1582345123,
     "wof:name":"Apaneca",
     "wof:parent_id":85677139,
     "wof:placetype":"county",

--- a/data/421/188/901/421188901.geojson
+++ b/data/421/188/901/421188901.geojson
@@ -90,6 +90,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459009587,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8f518c8b7d1ed3c0919a473521e22ea1",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
         }
     ],
     "wof:id":421188901,
-    "wof:lastmodified":1566651035,
+    "wof:lastmodified":1582345122,
     "wof:name":"Concepcion De Ataco",
     "wof:parent_id":85677139,
     "wof:placetype":"county",

--- a/data/421/189/127/421189127.geojson
+++ b/data/421/189/127/421189127.geojson
@@ -158,6 +158,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459009605,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ea3deee1b59debd2fc084543352e67bd",
     "wof:hierarchy":[
         {
@@ -168,7 +171,7 @@
         }
     ],
     "wof:id":421189127,
-    "wof:lastmodified":1566651034,
+    "wof:lastmodified":1582345122,
     "wof:name":"Colon",
     "wof:parent_id":85677151,
     "wof:placetype":"county",

--- a/data/421/189/131/421189131.geojson
+++ b/data/421/189/131/421189131.geojson
@@ -107,6 +107,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459009605,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1d582220328f41e99b7322bbb1490990",
     "wof:hierarchy":[
         {
@@ -117,7 +120,7 @@
         }
     ],
     "wof:id":421189131,
-    "wof:lastmodified":1566651035,
+    "wof:lastmodified":1582345122,
     "wof:name":"Comasagua",
     "wof:parent_id":85677151,
     "wof:placetype":"county",

--- a/data/421/189/133/421189133.geojson
+++ b/data/421/189/133/421189133.geojson
@@ -134,6 +134,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459009606,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e6d6c51407406a3e828cf8df98f71ae4",
     "wof:hierarchy":[
         {
@@ -144,7 +147,7 @@
         }
     ],
     "wof:id":421189133,
-    "wof:lastmodified":1566651034,
+    "wof:lastmodified":1582345122,
     "wof:name":"Ilopango",
     "wof:parent_id":85677163,
     "wof:placetype":"county",

--- a/data/421/189/135/421189135.geojson
+++ b/data/421/189/135/421189135.geojson
@@ -122,6 +122,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459009611,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4ae24d606e0fde06052939380deb9f4a",
     "wof:hierarchy":[
         {
@@ -132,7 +135,7 @@
         }
     ],
     "wof:id":421189135,
-    "wof:lastmodified":1566651034,
+    "wof:lastmodified":1582345122,
     "wof:name":"Nejapa",
     "wof:parent_id":85677163,
     "wof:placetype":"county",

--- a/data/421/189/151/421189151.geojson
+++ b/data/421/189/151/421189151.geojson
@@ -107,6 +107,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459009611,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5f61cc951313fe559a3285dd5da60aad",
     "wof:hierarchy":[
         {
@@ -117,7 +120,7 @@
         }
     ],
     "wof:id":421189151,
-    "wof:lastmodified":1566651034,
+    "wof:lastmodified":1582345122,
     "wof:name":"Caluco",
     "wof:parent_id":85677159,
     "wof:placetype":"county",

--- a/data/421/189/495/421189495.geojson
+++ b/data/421/189/495/421189495.geojson
@@ -104,6 +104,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459009627,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"de2d311f2f900e0fa2f958cadd118014",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
         }
     ],
     "wof:id":421189495,
-    "wof:lastmodified":1566651035,
+    "wof:lastmodified":1582345122,
     "wof:name":"San Francisco Gotera",
     "wof:parent_id":85677173,
     "wof:placetype":"county",

--- a/data/421/189/499/421189499.geojson
+++ b/data/421/189/499/421189499.geojson
@@ -107,6 +107,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459009627,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7c940141b4c1b363b5bc160793f9241e",
     "wof:hierarchy":[
         {
@@ -117,7 +120,7 @@
         }
     ],
     "wof:id":421189499,
-    "wof:lastmodified":1566651034,
+    "wof:lastmodified":1582345122,
     "wof:name":"San Pedro Perulapan",
     "wof:parent_id":85677145,
     "wof:placetype":"county",

--- a/data/421/189/501/421189501.geojson
+++ b/data/421/189/501/421189501.geojson
@@ -112,6 +112,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459009627,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"936682d1f01f70065fec316bce7df898",
     "wof:hierarchy":[
         {
@@ -122,7 +125,7 @@
         }
     ],
     "wof:id":421189501,
-    "wof:lastmodified":1566651035,
+    "wof:lastmodified":1582345122,
     "wof:name":"San Jorge",
     "wof:parent_id":85677177,
     "wof:placetype":"county",

--- a/data/421/190/155/421190155.geojson
+++ b/data/421/190/155/421190155.geojson
@@ -103,6 +103,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459009648,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d810d35c26e054208472d24a333ac1bb",
     "wof:hierarchy":[
         {
@@ -113,7 +116,7 @@
         }
     ],
     "wof:id":421190155,
-    "wof:lastmodified":1566651045,
+    "wof:lastmodified":1582345123,
     "wof:name":"Coatepeque",
     "wof:parent_id":85677195,
     "wof:placetype":"county",

--- a/data/421/190/511/421190511.geojson
+++ b/data/421/190/511/421190511.geojson
@@ -117,6 +117,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459009660,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8092013bede4f00dd3e06d71f1de9010",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":421190511,
-    "wof:lastmodified":1566651044,
+    "wof:lastmodified":1582345123,
     "wof:name":"Candelaria De La Frontera",
     "wof:parent_id":85677195,
     "wof:placetype":"county",

--- a/data/421/190/525/421190525.geojson
+++ b/data/421/190/525/421190525.geojson
@@ -104,6 +104,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459009660,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3fd9e2c779df567b09acb591c6e1abed",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
         }
     ],
     "wof:id":421190525,
-    "wof:lastmodified":1566651046,
+    "wof:lastmodified":1582345123,
     "wof:name":"Tejutepeque",
     "wof:parent_id":85677141,
     "wof:placetype":"county",

--- a/data/421/191/203/421191203.geojson
+++ b/data/421/191/203/421191203.geojson
@@ -141,6 +141,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459009684,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"212c8c018aca6f4005ed697679e41ac9",
     "wof:hierarchy":[
         {
@@ -151,7 +154,7 @@
         }
     ],
     "wof:id":421191203,
-    "wof:lastmodified":1566651043,
+    "wof:lastmodified":1582345123,
     "wof:name":"San Ignacio",
     "wof:parent_id":85677193,
     "wof:placetype":"county",

--- a/data/421/191/205/421191205.geojson
+++ b/data/421/191/205/421191205.geojson
@@ -94,6 +94,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459009684,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e8fce8b0e231a61177410cecab4a41a9",
     "wof:hierarchy":[
         {
@@ -104,7 +107,7 @@
         }
     ],
     "wof:id":421191205,
-    "wof:lastmodified":1566651043,
+    "wof:lastmodified":1582345123,
     "wof:name":"Chalatenango",
     "wof:parent_id":85677193,
     "wof:placetype":"county",

--- a/data/421/191/209/421191209.geojson
+++ b/data/421/191/209/421191209.geojson
@@ -104,6 +104,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459009684,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d1dab2326c2e7020cfd9b98b8e680029",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
         }
     ],
     "wof:id":421191209,
-    "wof:lastmodified":1566651044,
+    "wof:lastmodified":1582345123,
     "wof:name":"Citala",
     "wof:parent_id":85677193,
     "wof:placetype":"county",

--- a/data/421/191/211/421191211.geojson
+++ b/data/421/191/211/421191211.geojson
@@ -110,6 +110,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459009684,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"171e270a11d65bd26460c834c07ca402",
     "wof:hierarchy":[
         {
@@ -120,7 +123,7 @@
         }
     ],
     "wof:id":421191211,
-    "wof:lastmodified":1566651041,
+    "wof:lastmodified":1582345123,
     "wof:name":"Ciudad Arce",
     "wof:parent_id":85677151,
     "wof:placetype":"county",

--- a/data/421/191/215/421191215.geojson
+++ b/data/421/191/215/421191215.geojson
@@ -104,6 +104,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459009684,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6d4a04f6bc3689b77ba832d13322ff0b",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
         }
     ],
     "wof:id":421191215,
-    "wof:lastmodified":1566651043,
+    "wof:lastmodified":1582345123,
     "wof:name":"Teotepeque",
     "wof:parent_id":85677151,
     "wof:placetype":"county",

--- a/data/421/191/217/421191217.geojson
+++ b/data/421/191/217/421191217.geojson
@@ -143,6 +143,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459009684,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"61ea0d6b18ec8c1b1d7052d5fd669582",
     "wof:hierarchy":[
         {
@@ -153,7 +156,7 @@
         }
     ],
     "wof:id":421191217,
-    "wof:lastmodified":1566651043,
+    "wof:lastmodified":1582345123,
     "wof:name":"Zacatecoluca",
     "wof:parent_id":85677155,
     "wof:placetype":"county",

--- a/data/421/191/219/421191219.geojson
+++ b/data/421/191/219/421191219.geojson
@@ -104,6 +104,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459009684,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"229e93523350d21b691f415dbb7781b6",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
         }
     ],
     "wof:id":421191219,
-    "wof:lastmodified":1566651042,
+    "wof:lastmodified":1582345123,
     "wof:name":"San Francisco Chinameca",
     "wof:parent_id":85677155,
     "wof:placetype":"county",

--- a/data/421/191/221/421191221.geojson
+++ b/data/421/191/221/421191221.geojson
@@ -107,6 +107,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459009684,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"782ac16bb587efb1188d1e1cd50e1db2",
     "wof:hierarchy":[
         {
@@ -117,7 +120,7 @@
         }
     ],
     "wof:id":421191221,
-    "wof:lastmodified":1566651042,
+    "wof:lastmodified":1582345123,
     "wof:name":"Conchagua",
     "wof:parent_id":85677169,
     "wof:placetype":"county",

--- a/data/421/191/227/421191227.geojson
+++ b/data/421/191/227/421191227.geojson
@@ -185,6 +185,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459009684,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"693374eff56b49b465de0266d555a2b1",
     "wof:hierarchy":[
         {
@@ -195,7 +198,7 @@
         }
     ],
     "wof:id":421191227,
-    "wof:lastmodified":1566651041,
+    "wof:lastmodified":1582345123,
     "wof:name":"La Union",
     "wof:parent_id":85677169,
     "wof:placetype":"county",

--- a/data/421/191/471/421191471.geojson
+++ b/data/421/191/471/421191471.geojson
@@ -100,6 +100,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459009694,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0de0d216ba8ecc616e38389355cc6599",
     "wof:hierarchy":[
         {
@@ -110,7 +113,7 @@
         }
     ],
     "wof:id":421191471,
-    "wof:lastmodified":1566651042,
+    "wof:lastmodified":1582345123,
     "wof:name":"Tenancingo",
     "wof:parent_id":85677145,
     "wof:placetype":"county",

--- a/data/421/191/473/421191473.geojson
+++ b/data/421/191/473/421191473.geojson
@@ -101,6 +101,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459009694,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a517410799f446167276ffdf90b3092d",
     "wof:hierarchy":[
         {
@@ -111,7 +114,7 @@
         }
     ],
     "wof:id":421191473,
-    "wof:lastmodified":1566651044,
+    "wof:lastmodified":1582345123,
     "wof:name":"Jocoaitique",
     "wof:parent_id":85677173,
     "wof:placetype":"county",

--- a/data/421/191/475/421191475.geojson
+++ b/data/421/191/475/421191475.geojson
@@ -78,6 +78,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459009694,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c48888f4a60d0b2b7d526ef99fe00681",
     "wof:hierarchy":[
         {
@@ -88,7 +91,7 @@
         }
     ],
     "wof:id":421191475,
-    "wof:lastmodified":1566651043,
+    "wof:lastmodified":1582345123,
     "wof:name":"Meanguera",
     "wof:parent_id":85677173,
     "wof:placetype":"county",

--- a/data/421/191/479/421191479.geojson
+++ b/data/421/191/479/421191479.geojson
@@ -107,6 +107,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459009694,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"85e44cd316c78384cf27294f9eb7bd30",
     "wof:hierarchy":[
         {
@@ -117,7 +120,7 @@
         }
     ],
     "wof:id":421191479,
-    "wof:lastmodified":1566651043,
+    "wof:lastmodified":1582345123,
     "wof:name":"Perquin",
     "wof:parent_id":85677173,
     "wof:placetype":"county",

--- a/data/421/191/785/421191785.geojson
+++ b/data/421/191/785/421191785.geojson
@@ -440,6 +440,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459009709,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"74d4d2389515d427a09866093241c3b6",
     "wof:hierarchy":[
         {
@@ -451,7 +454,7 @@
         }
     ],
     "wof:id":421191785,
-    "wof:lastmodified":1566651043,
+    "wof:lastmodified":1582345123,
     "wof:name":"San Salvador",
     "wof:parent_id":421180907,
     "wof:placetype":"locality",

--- a/data/421/193/371/421193371.geojson
+++ b/data/421/193/371/421193371.geojson
@@ -119,6 +119,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459009769,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"206d3bd33ac84308eb7267405e3449ab",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":421193371,
-    "wof:lastmodified":1566651025,
+    "wof:lastmodified":1582345121,
     "wof:name":"Tacuba",
     "wof:parent_id":85677139,
     "wof:placetype":"county",

--- a/data/421/194/513/421194513.geojson
+++ b/data/421/194/513/421194513.geojson
@@ -279,6 +279,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459009810,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"177adb5ba5c2117b3772962297d0303e",
     "wof:hierarchy":[
         {
@@ -290,7 +293,7 @@
         }
     ],
     "wof:id":421194513,
-    "wof:lastmodified":1566651024,
+    "wof:lastmodified":1582345121,
     "wof:name":"Chalatenango",
     "wof:parent_id":421191205,
     "wof:placetype":"locality",

--- a/data/421/195/553/421195553.geojson
+++ b/data/421/195/553/421195553.geojson
@@ -116,6 +116,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459009852,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"603699573518a0beea89080bb8da0760",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":421195553,
-    "wof:lastmodified":1566651023,
+    "wof:lastmodified":1582345121,
     "wof:name":"Antiguo Cuscatlan",
     "wof:parent_id":85677151,
     "wof:placetype":"county",

--- a/data/421/195/555/421195555.geojson
+++ b/data/421/195/555/421195555.geojson
@@ -116,6 +116,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459009852,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0c62e353547c9a8016133b615a08bce6",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":421195555,
-    "wof:lastmodified":1566651023,
+    "wof:lastmodified":1582345121,
     "wof:name":"Ciudad Barrios",
     "wof:parent_id":85677177,
     "wof:placetype":"county",

--- a/data/421/195/557/421195557.geojson
+++ b/data/421/195/557/421195557.geojson
@@ -101,6 +101,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459009852,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"364e3b3ebc4b2b6f02d7246c05e4ad3b",
     "wof:hierarchy":[
         {
@@ -111,7 +114,7 @@
         }
     ],
     "wof:id":421195557,
-    "wof:lastmodified":1566651023,
+    "wof:lastmodified":1582345121,
     "wof:name":"San Antonio Del Monte",
     "wof:parent_id":85677159,
     "wof:placetype":"county",

--- a/data/421/197/065/421197065.geojson
+++ b/data/421/197/065/421197065.geojson
@@ -148,6 +148,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459009901,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1bd68a2397a86979d449909261834d9e",
     "wof:hierarchy":[
         {
@@ -158,7 +161,7 @@
         }
     ],
     "wof:id":421197065,
-    "wof:lastmodified":1566651046,
+    "wof:lastmodified":1582345123,
     "wof:name":"Dolores",
     "wof:parent_id":85677141,
     "wof:placetype":"county",

--- a/data/421/201/175/421201175.geojson
+++ b/data/421/201/175/421201175.geojson
@@ -175,6 +175,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459010064,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bf6e29715355f0c07a416305a45cbb4e",
     "wof:hierarchy":[
         {
@@ -185,7 +188,7 @@
         }
     ],
     "wof:id":421201175,
-    "wof:lastmodified":1566651048,
+    "wof:lastmodified":1582345123,
     "wof:name":"San Miguel",
     "wof:parent_id":85677177,
     "wof:placetype":"county",

--- a/data/421/201/523/421201523.geojson
+++ b/data/421/201/523/421201523.geojson
@@ -116,6 +116,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459010075,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"601667368e33ad88ce3d34637262dc5b",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":421201523,
-    "wof:lastmodified":1566651049,
+    "wof:lastmodified":1582345123,
     "wof:name":"Sonzacate",
     "wof:parent_id":85677159,
     "wof:placetype":"county",

--- a/data/421/203/377/421203377.geojson
+++ b/data/421/203/377/421203377.geojson
@@ -124,6 +124,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459010149,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f1af34a84371827f8ffe436fa8c3d0c9",
     "wof:hierarchy":[
         {
@@ -134,7 +137,7 @@
         }
     ],
     "wof:id":421203377,
-    "wof:lastmodified":1566651028,
+    "wof:lastmodified":1582345122,
     "wof:name":"El Rosario",
     "wof:parent_id":85677145,
     "wof:placetype":"county",

--- a/data/421/203/589/421203589.geojson
+++ b/data/421/203/589/421203589.geojson
@@ -122,6 +122,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459010157,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0443b83901b8567d6ee788be74eb517d",
     "wof:hierarchy":[
         {
@@ -132,7 +135,7 @@
         }
     ],
     "wof:id":421203589,
-    "wof:lastmodified":1566651029,
+    "wof:lastmodified":1582345122,
     "wof:name":"San Francisco Menendez",
     "wof:parent_id":85677139,
     "wof:placetype":"county",

--- a/data/421/203/593/421203593.geojson
+++ b/data/421/203/593/421203593.geojson
@@ -103,6 +103,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459010157,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"68c0a6e4ca92f91960ed8f0e592b1d86",
     "wof:hierarchy":[
         {
@@ -113,7 +116,7 @@
         }
     ],
     "wof:id":421203593,
-    "wof:lastmodified":1566651028,
+    "wof:lastmodified":1582345122,
     "wof:name":"San Dionisio",
     "wof:parent_id":85677187,
     "wof:placetype":"county",

--- a/data/421/203/731/421203731.geojson
+++ b/data/421/203/731/421203731.geojson
@@ -182,6 +182,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459010161,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3e37c013119669aeb3a1e964975912cd",
     "wof:hierarchy":[
         {
@@ -192,7 +195,7 @@
         }
     ],
     "wof:id":421203731,
-    "wof:lastmodified":1566651028,
+    "wof:lastmodified":1582345122,
     "wof:name":"Chirilagua",
     "wof:parent_id":85677177,
     "wof:placetype":"county",

--- a/data/421/203/733/421203733.geojson
+++ b/data/421/203/733/421203733.geojson
@@ -152,6 +152,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459010162,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ed6e0d1585f4c3019fac3c36a359def8",
     "wof:hierarchy":[
         {
@@ -162,7 +165,7 @@
         }
     ],
     "wof:id":421203733,
-    "wof:lastmodified":1566651029,
+    "wof:lastmodified":1582345122,
     "wof:name":"Soyapango",
     "wof:parent_id":85677163,
     "wof:placetype":"county",

--- a/data/421/203/737/421203737.geojson
+++ b/data/421/203/737/421203737.geojson
@@ -110,6 +110,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459010162,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ad5e4558f8c85c3a1dd30cd6373b75fb",
     "wof:hierarchy":[
         {
@@ -120,7 +123,7 @@
         }
     ],
     "wof:id":421203737,
-    "wof:lastmodified":1566651028,
+    "wof:lastmodified":1582345122,
     "wof:name":"San Martin",
     "wof:parent_id":85677163,
     "wof:placetype":"county",

--- a/data/421/203/739/421203739.geojson
+++ b/data/421/203/739/421203739.geojson
@@ -786,6 +786,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459010162,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8c4abc993b2ccb6b53fb76a9d14624f6",
     "wof:hierarchy":[
         {
@@ -796,7 +799,7 @@
         }
     ],
     "wof:id":421203739,
-    "wof:lastmodified":1566651028,
+    "wof:lastmodified":1582345122,
     "wof:name":"Armenia",
     "wof:parent_id":85677159,
     "wof:placetype":"county",

--- a/data/421/203/741/421203741.geojson
+++ b/data/421/203/741/421203741.geojson
@@ -104,6 +104,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459010162,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"35f4a79e49b371e16cf8c195bf53270e",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
         }
     ],
     "wof:id":421203741,
-    "wof:lastmodified":1566651029,
+    "wof:lastmodified":1582345122,
     "wof:name":"Santiago Texacuangos",
     "wof:parent_id":85677163,
     "wof:placetype":"county",

--- a/data/421/203/743/421203743.geojson
+++ b/data/421/203/743/421203743.geojson
@@ -113,6 +113,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459010162,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d368aae269e7e667fe6d9e97e9421f1d",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
         }
     ],
     "wof:id":421203743,
-    "wof:lastmodified":1566651030,
+    "wof:lastmodified":1582345122,
     "wof:name":"Tonacatepeque",
     "wof:parent_id":85677163,
     "wof:placetype":"county",

--- a/data/421/203/745/421203745.geojson
+++ b/data/421/203/745/421203745.geojson
@@ -107,6 +107,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459010162,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8dab97ea8ce0797c7c4db2ddd534d7fb",
     "wof:hierarchy":[
         {
@@ -117,7 +120,7 @@
         }
     ],
     "wof:id":421203745,
-    "wof:lastmodified":1566651030,
+    "wof:lastmodified":1582345122,
     "wof:name":"Texistepeque",
     "wof:parent_id":85677195,
     "wof:placetype":"county",

--- a/data/421/203/747/421203747.geojson
+++ b/data/421/203/747/421203747.geojson
@@ -107,6 +107,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459010162,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"dd49bbf314dd3300804815d655e89c31",
     "wof:hierarchy":[
         {
@@ -117,7 +120,7 @@
         }
     ],
     "wof:id":421203747,
-    "wof:lastmodified":1566651029,
+    "wof:lastmodified":1582345122,
     "wof:name":"Apastepeque",
     "wof:parent_id":85677185,
     "wof:placetype":"county",

--- a/data/421/203/751/421203751.geojson
+++ b/data/421/203/751/421203751.geojson
@@ -235,6 +235,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459010162,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a453b6d89d9d429bf2a3ece388ee7bd0",
     "wof:hierarchy":[
         {
@@ -245,7 +248,7 @@
         }
     ],
     "wof:id":421203751,
-    "wof:lastmodified":1566651029,
+    "wof:lastmodified":1582345122,
     "wof:name":"San Carlos",
     "wof:parent_id":85677173,
     "wof:placetype":"county",

--- a/data/421/204/283/421204283.geojson
+++ b/data/421/204/283/421204283.geojson
@@ -107,6 +107,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459010179,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ca616909a12f79b648c012a13e0ef08c",
     "wof:hierarchy":[
         {
@@ -117,7 +120,7 @@
         }
     ],
     "wof:id":421204283,
-    "wof:lastmodified":1566651027,
+    "wof:lastmodified":1582345122,
     "wof:name":"Jujutla",
     "wof:parent_id":85677139,
     "wof:placetype":"county",

--- a/data/421/205/339/421205339.geojson
+++ b/data/421/205/339/421205339.geojson
@@ -110,6 +110,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459010221,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"888e3be62b68670e46733664b79e7ef6",
     "wof:hierarchy":[
         {
@@ -120,7 +123,7 @@
         }
     ],
     "wof:id":421205339,
-    "wof:lastmodified":1566651031,
+    "wof:lastmodified":1582345122,
     "wof:name":"Nahuizalco",
     "wof:parent_id":85677159,
     "wof:placetype":"county",

--- a/data/421/205/341/421205341.geojson
+++ b/data/421/205/341/421205341.geojson
@@ -79,6 +79,9 @@
     },
     "wof:country":"SV",
     "wof:created":1459010221,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a51a36cded446b95af5619fa84472d95",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
         }
     ],
     "wof:id":421205341,
-    "wof:lastmodified":1566651031,
+    "wof:lastmodified":1582345122,
     "wof:name":"Usulutan",
     "wof:parent_id":85677187,
     "wof:placetype":"county",

--- a/data/856/325/45/85632545.geojson
+++ b/data/856/325/45/85632545.geojson
@@ -938,7 +938,6 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[
         "naturalearth",
-        "naturalearth",
         "meso"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -1013,7 +1012,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1582345117,
+    "wof:lastmodified":1583223923,
     "wof:name":"El Salvador",
     "wof:parent_id":102191575,
     "wof:placetype":"country",

--- a/data/856/325/45/85632545.geojson
+++ b/data/856/325/45/85632545.geojson
@@ -938,6 +938,7 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[
         "naturalearth",
+        "naturalearth",
         "meso"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -993,6 +994,11 @@
     },
     "wof:country":"SV",
     "wof:country_alpha3":"SLV",
+    "wof:geom_alt":[
+        "naturalearth-display-terrestrial-zoom6",
+        "naturalearth",
+        "meso"
+    ],
     "wof:geomhash":"2f96094221058787323be45de2d52204",
     "wof:hierarchy":[
         {
@@ -1007,7 +1013,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566650759,
+    "wof:lastmodified":1582345117,
     "wof:name":"El Salvador",
     "wof:parent_id":102191575,
     "wof:placetype":"country",

--- a/data/856/771/39/85677139.geojson
+++ b/data/856/771/39/85677139.geojson
@@ -307,6 +307,9 @@
         "wk:page":"Ahuachap\u00e1n Department"
     },
     "wof:country":"SV",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8164d649fbad895bf6aefe5fcdf85032",
     "wof:hierarchy":[
         {
@@ -322,7 +325,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566650758,
+    "wof:lastmodified":1582345117,
     "wof:name":"Ahuachap\u00e1n",
     "wof:parent_id":85632545,
     "wof:placetype":"region",

--- a/data/856/771/41/85677141.geojson
+++ b/data/856/771/41/85677141.geojson
@@ -299,6 +299,9 @@
         "wk:page":"Caba\u00f1as Department"
     },
     "wof:country":"SV",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8d13f899bc91496821eb22cc96b4424f",
     "wof:hierarchy":[
         {
@@ -314,7 +317,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566650759,
+    "wof:lastmodified":1582345117,
     "wof:name":"Caba\u00f1as",
     "wof:parent_id":85632545,
     "wof:placetype":"region",

--- a/data/856/771/45/85677145.geojson
+++ b/data/856/771/45/85677145.geojson
@@ -298,6 +298,9 @@
         "wk:page":"Cuscatl\u00e1n Department"
     },
     "wof:country":"SV",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d2a33a04155ce4376191bc993139fe40",
     "wof:hierarchy":[
         {
@@ -313,7 +316,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566650758,
+    "wof:lastmodified":1582345117,
     "wof:name":"Cuscatl\u00e1n",
     "wof:parent_id":85632545,
     "wof:placetype":"region",

--- a/data/856/771/51/85677151.geojson
+++ b/data/856/771/51/85677151.geojson
@@ -299,6 +299,9 @@
         "wk:page":"La Libertad Department (El Salvador)"
     },
     "wof:country":"SV",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ecd22df5806d0cd980fe0eea89e61d81",
     "wof:hierarchy":[
         {
@@ -314,7 +317,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566650757,
+    "wof:lastmodified":1582345116,
     "wof:name":"La Libertad",
     "wof:parent_id":85632545,
     "wof:placetype":"region",

--- a/data/856/771/55/85677155.geojson
+++ b/data/856/771/55/85677155.geojson
@@ -296,6 +296,9 @@
         "wk:page":"La Paz Department (El Salvador)"
     },
     "wof:country":"SV",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1e6d924354998333d59741ed8ade1559",
     "wof:hierarchy":[
         {
@@ -311,7 +314,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566650759,
+    "wof:lastmodified":1582345117,
     "wof:name":"La Paz",
     "wof:parent_id":85632545,
     "wof:placetype":"region",

--- a/data/856/771/59/85677159.geojson
+++ b/data/856/771/59/85677159.geojson
@@ -275,6 +275,9 @@
         "wk:page":"Sonsonate Department"
     },
     "wof:country":"SV",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fbcf0b1b14bad09c01c2f32427fdc08f",
     "wof:hierarchy":[
         {
@@ -290,7 +293,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566650757,
+    "wof:lastmodified":1582345116,
     "wof:name":"Sonsonate",
     "wof:parent_id":85632545,
     "wof:placetype":"region",

--- a/data/856/771/63/85677163.geojson
+++ b/data/856/771/63/85677163.geojson
@@ -304,6 +304,9 @@
         "wk:page":"San Salvador Department"
     },
     "wof:country":"SV",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8737522a940f12908455f6d6f8cefe82",
     "wof:hierarchy":[
         {
@@ -319,7 +322,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566650759,
+    "wof:lastmodified":1582345117,
     "wof:name":"San Salvador",
     "wof:parent_id":85632545,
     "wof:placetype":"region",

--- a/data/856/771/69/85677169.geojson
+++ b/data/856/771/69/85677169.geojson
@@ -247,6 +247,9 @@
         "wk:page":"La Uni\u00f3n Department"
     },
     "wof:country":"SV",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c176ba89f63a57fccfc455a67ea1befc",
     "wof:hierarchy":[
         {
@@ -262,7 +265,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566650757,
+    "wof:lastmodified":1582345116,
     "wof:name":"La Uni\u00f3n",
     "wof:parent_id":85632545,
     "wof:placetype":"region",

--- a/data/856/771/73/85677173.geojson
+++ b/data/856/771/73/85677173.geojson
@@ -298,6 +298,9 @@
         "wk:page":"Moraz\u00e1n Department"
     },
     "wof:country":"SV",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e32770d0727d31d369f7bca575d4b02f",
     "wof:hierarchy":[
         {
@@ -313,7 +316,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566650758,
+    "wof:lastmodified":1582345117,
     "wof:name":"Moraz\u00e1n",
     "wof:parent_id":85632545,
     "wof:placetype":"region",

--- a/data/856/771/77/85677177.geojson
+++ b/data/856/771/77/85677177.geojson
@@ -297,6 +297,9 @@
         "wk:page":"San Miguel Department (El Salvador)"
     },
     "wof:country":"SV",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c3e9ea51375f02129ddab96cff421396",
     "wof:hierarchy":[
         {
@@ -312,7 +315,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566650759,
+    "wof:lastmodified":1582345117,
     "wof:name":"San Miguel",
     "wof:parent_id":85632545,
     "wof:placetype":"region",

--- a/data/856/771/85/85677185.geojson
+++ b/data/856/771/85/85677185.geojson
@@ -297,6 +297,9 @@
         "wk:page":"San Vicente Department"
     },
     "wof:country":"SV",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"dccd00f6ae6cdddeef2582ce1c72cbb0",
     "wof:hierarchy":[
         {
@@ -312,7 +315,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566650759,
+    "wof:lastmodified":1582345117,
     "wof:name":"San Vicente",
     "wof:parent_id":85632545,
     "wof:placetype":"region",

--- a/data/856/771/87/85677187.geojson
+++ b/data/856/771/87/85677187.geojson
@@ -300,6 +300,9 @@
         "wk:page":"Usulut\u00e1n Department"
     },
     "wof:country":"SV",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4b9142523994f7d120bd48048a016523",
     "wof:hierarchy":[
         {
@@ -315,7 +318,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566650758,
+    "wof:lastmodified":1582345117,
     "wof:name":"Usulut\u00e1n",
     "wof:parent_id":85632545,
     "wof:placetype":"region",

--- a/data/856/771/93/85677193.geojson
+++ b/data/856/771/93/85677193.geojson
@@ -245,6 +245,9 @@
         "wk:page":"Chalatenango Department"
     },
     "wof:country":"SV",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a98209b0d7501e777387a8dff3923774",
     "wof:hierarchy":[
         {
@@ -260,7 +263,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566650758,
+    "wof:lastmodified":1582345116,
     "wof:name":"Chalatenango",
     "wof:parent_id":85632545,
     "wof:placetype":"region",

--- a/data/856/771/95/85677195.geojson
+++ b/data/856/771/95/85677195.geojson
@@ -292,6 +292,9 @@
         "wk:page":"Santa Ana Department"
     },
     "wof:country":"SV",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2e7fe989585172ad4b61e32e0368f7e6",
     "wof:hierarchy":[
         {
@@ -307,7 +310,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566650757,
+    "wof:lastmodified":1582345116,
     "wof:name":"Santa Ana",
     "wof:parent_id":85632545,
     "wof:placetype":"region",

--- a/data/857/938/29/85793829.geojson
+++ b/data/857/938/29/85793829.geojson
@@ -78,6 +78,9 @@
         "qs:id":901610
     },
     "wof:country":"SV",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5b64022ae9e0466cb3e0803aa4fd7964",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379463,
+    "wof:lastmodified":1582345116,
     "wof:name":"Colonia Am\u00e9rica",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/938/33/85793833.geojson
+++ b/data/857/938/33/85793833.geojson
@@ -79,6 +79,9 @@
         "qs:id":901611
     },
     "wof:country":"SV",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"48a37724c3f35a416c4d0b2d43e27625",
     "wof:hierarchy":[
         {
@@ -94,7 +97,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379463,
+    "wof:lastmodified":1582345116,
     "wof:name":"Colonia Dolores",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/938/35/85793835.geojson
+++ b/data/857/938/35/85793835.geojson
@@ -99,6 +99,9 @@
         "qs_pg:id":1165075
     },
     "wof:country":"SV",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"54b4c4cd71a50e5f0fe63b4c33e3cac9",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566650756,
+    "wof:lastmodified":1582345116,
     "wof:name":"Colonia El Milagro",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/938/39/85793839.geojson
+++ b/data/857/938/39/85793839.geojson
@@ -83,6 +83,9 @@
         "qs:id":901612
     },
     "wof:country":"SV",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1a559a7eddeddbce60805bf092a86e5e",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379463,
+    "wof:lastmodified":1582345116,
     "wof:name":"Colonia Escal\u00f3n",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/938/45/85793845.geojson
+++ b/data/857/938/45/85793845.geojson
@@ -79,6 +79,9 @@
         "qs:id":982569
     },
     "wof:country":"SV",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7428bc9e634271d060428d289d48404f",
     "wof:hierarchy":[
         {
@@ -94,7 +97,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379463,
+    "wof:lastmodified":1582345116,
     "wof:name":"Colonia Las Delicias",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/938/49/85793849.geojson
+++ b/data/857/938/49/85793849.geojson
@@ -102,6 +102,9 @@
         "qs_pg:id":1082598
     },
     "wof:country":"SV",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ab95721a2877d45b6e1cf2272018a4e3",
     "wof:hierarchy":[
         {
@@ -117,7 +120,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566650756,
+    "wof:lastmodified":1582345116,
     "wof:name":"Colonia San Benito",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/938/53/85793853.geojson
+++ b/data/857/938/53/85793853.geojson
@@ -75,6 +75,9 @@
         "qs:id":887549
     },
     "wof:country":"SV",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"823484448515358eda4f768420b8ccf0",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379463,
+    "wof:lastmodified":1582345116,
     "wof:name":"Delicias del Norte",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/938/57/85793857.geojson
+++ b/data/857/938/57/85793857.geojson
@@ -429,6 +429,9 @@
         "qs_pg:id":238568
     },
     "wof:country":"SV",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"69de4c0ecce4d07edcd9ec0d1fd4ed71",
     "wof:hierarchy":[
         {
@@ -444,7 +447,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566650756,
+    "wof:lastmodified":1582345116,
     "wof:name":"Montserrat",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/858/982/13/85898213.geojson
+++ b/data/858/982/13/85898213.geojson
@@ -85,6 +85,10 @@
         "wk:page":"Moste District"
     },
     "wof:country":"SV",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"277b3d1ba34ef8e25e40af02fa0db2ee",
     "wof:hierarchy":[
         {
@@ -100,7 +104,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566650760,
+    "wof:lastmodified":1582345118,
     "wof:name":"Moste",
     "wof:parent_id":101752073,
     "wof:placetype":"neighbourhood",

--- a/data/858/982/19/85898219.geojson
+++ b/data/858/982/19/85898219.geojson
@@ -85,6 +85,10 @@
         "wk:page":"Spodnja \u0160i\u0161ka"
     },
     "wof:country":"SV",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ff8eeaaee9522c3024e721b4c63acdce",
     "wof:hierarchy":[
         {
@@ -100,7 +104,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566650760,
+    "wof:lastmodified":1582345118,
     "wof:name":"Spodnja Siska",
     "wof:parent_id":101752073,
     "wof:placetype":"neighbourhood",

--- a/data/858/982/25/85898225.geojson
+++ b/data/858/982/25/85898225.geojson
@@ -100,6 +100,10 @@
         "wk:page":"Zgornja \u0160i\u0161ka"
     },
     "wof:country":"SV",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3f4e97982d3e3dbc988f65f41a23b017",
     "wof:hierarchy":[
         {
@@ -115,7 +119,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566650761,
+    "wof:lastmodified":1582345118,
     "wof:name":"Zgornja Siska",
     "wof:parent_id":101752073,
     "wof:placetype":"neighbourhood",

--- a/data/859/297/21/85929721.geojson
+++ b/data/859/297/21/85929721.geojson
@@ -84,6 +84,10 @@
         "wk:page":"Jar\u0161e (Ljubljana)"
     },
     "wof:country":"SV",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"c49e683bb40d09524e25bba7e9b0d108",
     "wof:hierarchy":[
         {
@@ -99,7 +103,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566650755,
+    "wof:lastmodified":1582345116,
     "wof:name":"Jar\u0161e",
     "wof:parent_id":101752073,
     "wof:placetype":"neighbourhood",

--- a/data/859/297/27/85929727.geojson
+++ b/data/859/297/27/85929727.geojson
@@ -98,6 +98,10 @@
         "wd:id":"Q2000244"
     },
     "wof:country":"SV",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3d5a313d59dd3a70c9429afb22dedf2f",
     "wof:hierarchy":[
         {
@@ -113,7 +117,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566650755,
+    "wof:lastmodified":1582345116,
     "wof:name":"Center",
     "wof:parent_id":101752073,
     "wof:placetype":"neighbourhood",

--- a/data/859/297/31/85929731.geojson
+++ b/data/859/297/31/85929731.geojson
@@ -108,6 +108,9 @@
         "wd:id":"Q2469185"
     },
     "wof:country":"SV",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7fbd6995f673b885375860de692ea498",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566650756,
+    "wof:lastmodified":1582345116,
     "wof:name":"Be\u017eigrad",
     "wof:parent_id":101752073,
     "wof:placetype":"neighbourhood",

--- a/data/859/297/35/85929735.geojson
+++ b/data/859/297/35/85929735.geojson
@@ -302,6 +302,10 @@
         "wd:id":"Q16520673"
     },
     "wof:country":"SV",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"629e1f22c764bd7407d5ba565197a1b3",
     "wof:hierarchy":[
         {
@@ -317,7 +321,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566650755,
+    "wof:lastmodified":1582345116,
     "wof:name":"Siska",
     "wof:parent_id":101752073,
     "wof:placetype":"neighbourhood",

--- a/data/859/297/39/85929739.geojson
+++ b/data/859/297/39/85929739.geojson
@@ -107,6 +107,10 @@
         "wk:page":"Ro\u017enik, Grosuplje"
     },
     "wof:country":"SV",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ad525071dd3c79ea07c206171b1b9c41",
     "wof:hierarchy":[
         {
@@ -122,7 +126,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566650756,
+    "wof:lastmodified":1582345116,
     "wof:name":"Roznik",
     "wof:parent_id":101752073,
     "wof:placetype":"neighbourhood",

--- a/data/890/451/505/890451505.geojson
+++ b/data/890/451/505/890451505.geojson
@@ -83,6 +83,9 @@
     },
     "wof:country":"SV",
     "wof:created":1469052782,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c77fa36359ad2e36e57069d89740a2e9",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
         }
     ],
     "wof:id":890451505,
-    "wof:lastmodified":1566651060,
+    "wof:lastmodified":1582345124,
     "wof:name":"San Luis La Herradura",
     "wof:parent_id":85677155,
     "wof:placetype":"county",

--- a/data/890/452/037/890452037.geojson
+++ b/data/890/452/037/890452037.geojson
@@ -107,6 +107,9 @@
     },
     "wof:country":"SV",
     "wof:created":1469052802,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"050cdfd9443d8c223a61434b0cba5fb3",
     "wof:hierarchy":[
         {
@@ -117,7 +120,7 @@
         }
     ],
     "wof:id":890452037,
-    "wof:lastmodified":1566651060,
+    "wof:lastmodified":1582345124,
     "wof:name":"El Triunfo",
     "wof:parent_id":85677187,
     "wof:placetype":"county",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.