### PR TITLE
Name updates

### DIFF
--- a/data/421/176/207/421176207.geojson
+++ b/data/421/176/207/421176207.geojson
@@ -120,7 +120,7 @@
         "\u0633\u0646\u062a\u0627 \u0631\u0648\u0632\u0627 \u062f\u06d2 \u0644\u06cc\u0645\u0627 \u060c \u0644\u0627 \u06cc\u0648\u0646\u06cc\u0646"
     ],
     "name:urd_x_variant":[
-        "\u0633\u0646\u062a\u0627 \u0631\u0648\u0632\u0627 \u062f\u06d2 \u0644\u06cc\u0645\u0627 "
+        "\u0633\u0646\u062a\u0627 \u0631\u0648\u0632\u0627 \u062f\u06d2 \u0644\u06cc\u0645\u0627"
     ],
     "name:vie_x_preferred":[
         "Santa Rosa de Lima"
@@ -152,8 +152,8 @@
     "wof:belongsto":[
         102191575,
         85632545,
-        85677169,
-        1108695041
+        1108695041,
+        85677169
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -176,7 +176,7 @@
         }
     ],
     "wof:id":421176207,
-    "wof:lastmodified":1566651058,
+    "wof:lastmodified":1587163137,
     "wof:name":"Santa Rosa de Lima",
     "wof:parent_id":1108695041,
     "wof:placetype":"locality",

--- a/data/421/190/405/421190405.geojson
+++ b/data/421/190/405/421190405.geojson
@@ -21,7 +21,7 @@
         "\u0633\u0627\u0646 \u0641\u0631\u0627\u0646\u0633\u064a\u0633\u0643\u0648 \u063a\u0648\u062a\u064a\u0631\u0627"
     ],
     "name:ben_x_preferred":[
-        "\u09b8\u09be\u09a8 \u09ab\u09cd\u09b0\u09be\u09a8\u09cd\u09b8\u09bf\u09b8\u0995\u09cb \u0997\u09cb\u09a4\u09c7\u09b0\u09be "
+        "\u09b8\u09be\u09a8 \u09ab\u09cd\u09b0\u09be\u09a8\u09cd\u09b8\u09bf\u09b8\u0995\u09cb \u0997\u09cb\u09a4\u09c7\u09b0\u09be"
     ],
     "name:ceb_x_preferred":[
         "San Francisco"
@@ -45,7 +45,7 @@
         "San Francisco Gotera"
     ],
     "name:guj_x_preferred":[
-        "\u0ab8\u0abe\u0aa8 \u0aab\u0acd\u0ab0\u0abe\u0aa8\u0acd\u0ab8\u0abf\u0ab8\u0acd\u0a95\u0acb "
+        "\u0ab8\u0abe\u0aa8 \u0aab\u0acd\u0ab0\u0abe\u0aa8\u0acd\u0ab8\u0abf\u0ab8\u0acd\u0a95\u0acb"
     ],
     "name:hin_x_preferred":[
         "\u0938\u0948\u0928 \u092b\u094d\u0930\u093e\u0902\u0938\u093f\u0938\u094d\u0915\u094b \u0917\u094b\u091f\u0947\u0930\u093e"
@@ -250,8 +250,8 @@
     "wof:belongsto":[
         102191575,
         85632545,
-        85677173,
-        421189495
+        421189495,
+        85677173
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -274,7 +274,7 @@
         }
     ],
     "wof:id":421190405,
-    "wof:lastmodified":1566651045,
+    "wof:lastmodified":1587163137,
     "wof:name":"San Francisco",
     "wof:parent_id":421189495,
     "wof:placetype":"locality",

--- a/data/890/422/913/890422913.geojson
+++ b/data/890/422/913/890422913.geojson
@@ -37,6 +37,9 @@
     "name:arg_x_preferred":[
         "El Salvador"
     ],
+    "name:ary_x_preferred":[
+        "\u0635\u0627\u0644\u06a4\u0627\u062f\u0648\u0631"
+    ],
     "name:arz_x_preferred":[
         "\u0627\u0644\u0633\u0627\u0644\u0641\u0627\u062f\u0648\u0631"
     ],
@@ -106,6 +109,9 @@
     "name:che_x_preferred":[
         "\u0421\u0430\u043b\u044c\u0432\u0430\u0434\u043e\u0440"
     ],
+    "name:chy_x_preferred":[
+        "El Salvador"
+    ],
     "name:ckb_x_preferred":[
         "\u0626\u06ce\u0644\u0633\u0627\u0644\u06a4\u0627\u062f\u06c6\u0631"
     ],
@@ -119,6 +125,12 @@
         "El Salvador"
     ],
     "name:dan_x_preferred":[
+        "El Salvador"
+    ],
+    "name:deu_at_x_preferred":[
+        "El Salvador"
+    ],
+    "name:deu_ch_x_preferred":[
         "El Salvador"
     ],
     "name:deu_x_preferred":[
@@ -138,6 +150,12 @@
     ],
     "name:ell_x_preferred":[
         "\u0395\u03bb \u03a3\u03b1\u03bb\u03b2\u03b1\u03b4\u03cc\u03c1"
+    ],
+    "name:eng_ca_x_preferred":[
+        "El Salvador"
+    ],
+    "name:eng_gb_x_preferred":[
+        "El Salvador"
     ],
     "name:eng_x_preferred":[
         "El Salvador"
@@ -180,6 +198,9 @@
     ],
     "name:gag_x_preferred":[
         "El Salvador"
+    ],
+    "name:gcr_x_preferred":[
+        "Salvador"
     ],
     "name:gla_x_preferred":[
         "El Salbhador"
@@ -355,6 +376,9 @@
     "name:mon_x_preferred":[
         "\u0421\u0430\u043b\u044c\u0432\u0430\u0434\u043e\u0440"
     ],
+    "name:mri_x_preferred":[
+        "Te Whakaora"
+    ],
     "name:mrj_x_preferred":[
         "\u0421\u0430\u043b\u044c\u0432\u0430\u0434\u043e\u0440"
     ],
@@ -439,6 +463,9 @@
     "name:pol_x_preferred":[
         "Salwador"
     ],
+    "name:por_br_x_preferred":[
+        "El Salvador"
+    ],
     "name:por_x_preferred":[
         "El Salvador"
     ],
@@ -487,6 +514,9 @@
     "name:sme_x_preferred":[
         "El Salvador"
     ],
+    "name:smo_x_preferred":[
+        "El Salvador"
+    ],
     "name:sna_x_preferred":[
         "El Salvador"
     ],
@@ -505,6 +535,12 @@
     "name:srd_x_preferred":[
         "El Salvador"
     ],
+    "name:srp_ec_x_preferred":[
+        "\u0421\u0430\u043b\u0432\u0430\u0434\u043e\u0440"
+    ],
+    "name:srp_el_x_preferred":[
+        "Salvador"
+    ],
     "name:srp_x_preferred":[
         "\u0421\u0430\u043b\u0432\u0430\u0434\u043e\u0440"
     ],
@@ -522,6 +558,9 @@
     ],
     "name:szl_x_preferred":[
         "Salwad\u016fr"
+    ],
+    "name:szy_x_preferred":[
+        "El salvador"
     ],
     "name:tam_x_preferred":[
         "\u0b8e\u0bb2\u0bcd \u0b9a\u0bbe\u0bb2\u0bcd\u0bb5\u0b9f\u0bcb\u0bb0\u0bcd"
@@ -549,6 +588,9 @@
     ],
     "name:tur_x_preferred":[
         "El Salvador"
+    ],
+    "name:udm_x_preferred":[
+        "\u0421\u0430\u043b\u044c\u0432\u0430\u0434\u043e\u0440"
     ],
     "name:uig_x_preferred":[
         "\u0626\u06d5\u0644 \u0633\u0627\u0644\u06cb\u0627\u062f\u0648\u0631"
@@ -607,6 +649,12 @@
     "name:zha_x_preferred":[
         "El Salvador"
     ],
+    "name:zho_cn_x_preferred":[
+        "\u8428\u5c14\u74e6\u591a"
+    ],
+    "name:zho_tw_x_preferred":[
+        "\u85a9\u723e\u74e6\u591a"
+    ],
     "name:zho_x_preferred":[
         "\u8428\u5c14\u74e6\u591a"
     ],
@@ -625,8 +673,8 @@
     "wof:belongsto":[
         102191575,
         85632545,
-        85677151,
-        1108695045
+        1108695045,
+        85677151
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -649,7 +697,7 @@
         }
     ],
     "wof:id":890422913,
-    "wof:lastmodified":1566651060,
+    "wof:lastmodified":1587428000,
     "wof:name":"el salvador",
     "wof:parent_id":1108695045,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1796 and https://github.com/whosonfirst-data/whosonfirst-data/issues/1821.

This PR includes:
- Fixes to property values that start or end with `" "`, `\n`, or `\r`, removing those characters.
- Using a modified version of the [wiki names import script](https://github.com/whosonfirst/whosonfirst-cookbook/blob/master/scripts/crawl_to_add_wiki_names.py), adds new `name` properties

There will be ~260 similar PRs, one for each per-country repo. No PIP work require, can merge as-is.