### PR TITLE
Update megacity records

### DIFF
--- a/data/421/191/785/421191785.geojson
+++ b/data/421/191/785/421191785.geojson
@@ -436,6 +436,7 @@
         "gn:id":3583361,
         "gp:id":79825,
         "loc:id":"n79066410",
+        "ne:id":1159150853,
         "qs_pg:id":1155818,
         "wd:id":"Q3110",
         "wk:page":"San Salvador"
@@ -459,7 +460,8 @@
         }
     ],
     "wof:id":421191785,
-    "wof:lastmodified":1607980765,
+    "wof:lastmodified":1608688177,
+    "wof:megacity":1,
     "wof:name":"San Salvador",
     "wof:parent_id":421180907,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1547

- Updates megacity records with new:
  - concordances
  - names (if not already present)
  - label centroids
  - megacity flags
- Updates geometries of any megacity record with a `Point` geometry
- Updates parent geometries when necessary