### PR TITLE
sv concordances, placetype local, and more

### DIFF
--- a/data/110/869/470/5/1108694705.geojson
+++ b/data/110/869/470/5/1108694705.geojson
@@ -112,6 +112,7 @@
     "wof:concordances":{
         "hasc:id":"SV.SO.AC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493054,
     "wof:geomhash":"046cef166929be2de348b2a4efe2d43f",
@@ -124,7 +125,7 @@
         }
     ],
     "wof:id":1108694705,
-    "wof:lastmodified":1694492409,
+    "wof:lastmodified":1695886438,
     "wof:name":"Acajutla",
     "wof:parent_id":85677159,
     "wof:placetype":"county",

--- a/data/110/869/470/7/1108694707.geojson
+++ b/data/110/869/470/7/1108694707.geojson
@@ -73,6 +73,7 @@
     "wof:concordances":{
         "hasc:id":"SV.CH.AC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493055,
     "wof:geomhash":"e0992a7bb4c5912b512f445a6cb42527",
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108694707,
-    "wof:lastmodified":1694492794,
+    "wof:lastmodified":1695886494,
     "wof:name":"Agua Caliente",
     "wof:parent_id":85677193,
     "wof:placetype":"county",

--- a/data/110/869/471/1/1108694711.geojson
+++ b/data/110/869/471/1/1108694711.geojson
@@ -76,6 +76,7 @@
     "wof:concordances":{
         "hasc:id":"SV.SS.AG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493057,
     "wof:geomhash":"790ce315ed86d001c0906ca25856e020",
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1108694711,
-    "wof:lastmodified":1694492409,
+    "wof:lastmodified":1695886438,
     "wof:name":"Aguilares",
     "wof:parent_id":85677163,
     "wof:placetype":"county",

--- a/data/110/869/471/3/1108694713.geojson
+++ b/data/110/869/471/3/1108694713.geojson
@@ -86,6 +86,7 @@
     "wof:concordances":{
         "hasc:id":"SV.US.AL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493060,
     "wof:geomhash":"5c403b3be6c7d9976500582079924738",
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1108694713,
-    "wof:lastmodified":1694492794,
+    "wof:lastmodified":1695886494,
     "wof:name":"Alegria",
     "wof:parent_id":85677187,
     "wof:placetype":"county",

--- a/data/110/869/471/5/1108694715.geojson
+++ b/data/110/869/471/5/1108694715.geojson
@@ -59,6 +59,7 @@
     "wof:concordances":{
         "hasc:id":"SV.UN.AN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493062,
     "wof:geomhash":"aadc09b50a525f73160b92c8df8fb6bd",
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1108694715,
-    "wof:lastmodified":1694492794,
+    "wof:lastmodified":1695886494,
     "wof:name":"Anamoros",
     "wof:parent_id":85677169,
     "wof:placetype":"county",

--- a/data/110/869/471/7/1108694717.geojson
+++ b/data/110/869/471/7/1108694717.geojson
@@ -76,6 +76,7 @@
     "wof:concordances":{
         "hasc:id":"SV.CH.AR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493068,
     "wof:geomhash":"31f2d508cf7da471a4e732c0d22e4713",
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1108694717,
-    "wof:lastmodified":1694492794,
+    "wof:lastmodified":1695886494,
     "wof:name":"Arcatao",
     "wof:parent_id":85677193,
     "wof:placetype":"county",

--- a/data/110/869/471/9/1108694719.geojson
+++ b/data/110/869/471/9/1108694719.geojson
@@ -73,6 +73,7 @@
     "wof:concordances":{
         "hasc:id":"SV.CH.AZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493072,
     "wof:geomhash":"1d28984d4398a5164061d8484430d7db",
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108694719,
-    "wof:lastmodified":1694492409,
+    "wof:lastmodified":1695886438,
     "wof:name":"Azacualpa",
     "wof:parent_id":85677193,
     "wof:placetype":"county",

--- a/data/110/869/472/1/1108694721.geojson
+++ b/data/110/869/472/1/1108694721.geojson
@@ -758,6 +758,7 @@
     "wof:concordances":{
         "hasc:id":"SV.US.BE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493074,
     "wof:geomhash":"1b092acbdd534952c937a349a69f540d",
@@ -770,7 +771,7 @@
         }
     ],
     "wof:id":1108694721,
-    "wof:lastmodified":1694492410,
+    "wof:lastmodified":1695886440,
     "wof:name":"Berlin",
     "wof:parent_id":85677187,
     "wof:placetype":"county",

--- a/data/110/869/472/3/1108694723.geojson
+++ b/data/110/869/472/3/1108694723.geojson
@@ -62,6 +62,7 @@
     "wof:concordances":{
         "hasc:id":"SV.UN.BO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493076,
     "wof:geomhash":"22d23effe8d85c77d0171ead8e7ff1fd",
@@ -74,7 +75,7 @@
         }
     ],
     "wof:id":1108694723,
-    "wof:lastmodified":1694492931,
+    "wof:lastmodified":1695886760,
     "wof:name":"Bolivar",
     "wof:parent_id":85677169,
     "wof:placetype":"county",

--- a/data/110/869/472/5/1108694725.geojson
+++ b/data/110/869/472/5/1108694725.geojson
@@ -79,6 +79,7 @@
     "wof:concordances":{
         "hasc:id":"SV.MO.CA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493078,
     "wof:geomhash":"0e961e7c22baaaefaeeae00572e267ff",
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108694725,
-    "wof:lastmodified":1694492794,
+    "wof:lastmodified":1695886495,
     "wof:name":"Cacaopera",
     "wof:parent_id":85677173,
     "wof:placetype":"county",

--- a/data/110/869/472/9/1108694729.geojson
+++ b/data/110/869/472/9/1108694729.geojson
@@ -625,6 +625,7 @@
     "wof:concordances":{
         "hasc:id":"SV.US.CA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493080,
     "wof:geomhash":"effc4d4f3c38a37ba897ca936b7bdf30",
@@ -637,7 +638,7 @@
         }
     ],
     "wof:id":1108694729,
-    "wof:lastmodified":1694492409,
+    "wof:lastmodified":1695886440,
     "wof:name":"California",
     "wof:parent_id":85677187,
     "wof:placetype":"county",

--- a/data/110/869/473/1/1108694731.geojson
+++ b/data/110/869/473/1/1108694731.geojson
@@ -59,6 +59,7 @@
     "wof:concordances":{
         "hasc:id":"SV.CH.SC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493082,
     "wof:geomhash":"6c462af6a98d80e1100867225822e965",
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1108694731,
-    "wof:lastmodified":1694492794,
+    "wof:lastmodified":1695886495,
     "wof:name":"Cancasque",
     "wof:parent_id":85677193,
     "wof:placetype":"county",

--- a/data/110/869/473/3/1108694733.geojson
+++ b/data/110/869/473/3/1108694733.geojson
@@ -115,6 +115,7 @@
     "wof:concordances":{
         "hasc:id":"SV.CU.CA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493084,
     "wof:geomhash":"0dcd6059f27a5537bdf4f0ae6aa557f8",
@@ -127,7 +128,7 @@
         }
     ],
     "wof:id":1108694733,
-    "wof:lastmodified":1694492410,
+    "wof:lastmodified":1695886440,
     "wof:name":"Candelaria",
     "wof:parent_id":85677145,
     "wof:placetype":"county",

--- a/data/110/869/473/5/1108694735.geojson
+++ b/data/110/869/473/5/1108694735.geojson
@@ -154,6 +154,7 @@
     "wof:concordances":{
         "hasc:id":"SV.SM.CA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493086,
     "wof:geomhash":"5178bdbbda9b1568da904a37bb1590b3",
@@ -166,7 +167,7 @@
         }
     ],
     "wof:id":1108694735,
-    "wof:lastmodified":1694492410,
+    "wof:lastmodified":1695886441,
     "wof:name":"Carolina",
     "wof:parent_id":85677177,
     "wof:placetype":"county",

--- a/data/110/869/473/7/1108694737.geojson
+++ b/data/110/869/473/7/1108694737.geojson
@@ -97,6 +97,7 @@
     "wof:concordances":{
         "hasc:id":"SV.SA.CH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493089,
     "wof:geomhash":"d3fd8d4f29fb90067e73d1506f6106c8",
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1108694737,
-    "wof:lastmodified":1694492410,
+    "wof:lastmodified":1695886440,
     "wof:name":"Chalchuapa",
     "wof:parent_id":85677195,
     "wof:placetype":"county",

--- a/data/110/869/473/9/1108694739.geojson
+++ b/data/110/869/473/9/1108694739.geojson
@@ -73,6 +73,7 @@
     "wof:concordances":{
         "hasc:id":"SV.SM.CP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493090,
     "wof:geomhash":"2cee6fb6c18fae7aa40dc1c400d1165e",
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108694739,
-    "wof:lastmodified":1694492794,
+    "wof:lastmodified":1695886495,
     "wof:name":"Chapeltique",
     "wof:parent_id":85677177,
     "wof:placetype":"county",

--- a/data/110/869/474/1/1108694741.geojson
+++ b/data/110/869/474/1/1108694741.geojson
@@ -70,6 +70,7 @@
     "wof:concordances":{
         "hasc:id":"SV.MO.CH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493092,
     "wof:geomhash":"45d8331999c71b6e504c9d282b15b51d",
@@ -82,7 +83,7 @@
         }
     ],
     "wof:id":1108694741,
-    "wof:lastmodified":1694492794,
+    "wof:lastmodified":1695886495,
     "wof:name":"Chilanga",
     "wof:parent_id":85677173,
     "wof:placetype":"county",

--- a/data/110/869/474/3/1108694743.geojson
+++ b/data/110/869/474/3/1108694743.geojson
@@ -76,6 +76,7 @@
     "wof:concordances":{
         "hasc:id":"SV.SM.CM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493095,
     "wof:geomhash":"090130b97126736aa6d6b710165fbb22",
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1108694743,
-    "wof:lastmodified":1694492794,
+    "wof:lastmodified":1695886495,
     "wof:name":"Chinameca",
     "wof:parent_id":85677177,
     "wof:placetype":"county",

--- a/data/110/869/474/7/1108694747.geojson
+++ b/data/110/869/474/7/1108694747.geojson
@@ -73,6 +73,7 @@
     "wof:concordances":{
         "hasc:id":"SV.CA.CI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493098,
     "wof:geomhash":"434c1eb499684935df154a1e045c554b",
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108694747,
-    "wof:lastmodified":1694492410,
+    "wof:lastmodified":1695886441,
     "wof:name":"Cinquera",
     "wof:parent_id":85677141,
     "wof:placetype":"county",

--- a/data/110/869/474/9/1108694749.geojson
+++ b/data/110/869/474/9/1108694749.geojson
@@ -59,6 +59,7 @@
     "wof:concordances":{
         "hasc:id":"SV.SM.CO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493105,
     "wof:geomhash":"015ce3add95a988cb9c985ab9ac4acf2",
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1108694749,
-    "wof:lastmodified":1694492794,
+    "wof:lastmodified":1695886495,
     "wof:name":"Comacaran",
     "wof:parent_id":85677177,
     "wof:placetype":"county",

--- a/data/110/869/475/1/1108694751.geojson
+++ b/data/110/869/475/1/1108694751.geojson
@@ -79,6 +79,7 @@
     "wof:concordances":{
         "hasc:id":"SV.CH.CO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493106,
     "wof:geomhash":"fa8058ea90b5dacb48a99d7d4750cdb9",
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108694751,
-    "wof:lastmodified":1694492409,
+    "wof:lastmodified":1695886440,
     "wof:name":"Comalapa",
     "wof:parent_id":85677193,
     "wof:placetype":"county",

--- a/data/110/869/475/3/1108694753.geojson
+++ b/data/110/869/475/3/1108694753.geojson
@@ -59,6 +59,7 @@
     "wof:concordances":{
         "hasc:id":"SV.US.CB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493109,
     "wof:geomhash":"d369721160a0f84d26875903a84915f9",
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1108694753,
-    "wof:lastmodified":1694492794,
+    "wof:lastmodified":1695886495,
     "wof:name":"Concepcion Batres",
     "wof:parent_id":85677187,
     "wof:placetype":"county",

--- a/data/110/869/475/5/1108694755.geojson
+++ b/data/110/869/475/5/1108694755.geojson
@@ -59,6 +59,7 @@
     "wof:concordances":{
         "hasc:id":"SV.UN.CO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493113,
     "wof:geomhash":"7a1bed557c61f15b432677c1ea3d6f74",
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1108694755,
-    "wof:lastmodified":1694492794,
+    "wof:lastmodified":1695886495,
     "wof:name":"Concepcion De Oriente",
     "wof:parent_id":85677169,
     "wof:placetype":"county",

--- a/data/110/869/475/7/1108694757.geojson
+++ b/data/110/869/475/7/1108694757.geojson
@@ -59,6 +59,7 @@
     "wof:concordances":{
         "hasc:id":"SV.CH.CQ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493115,
     "wof:geomhash":"8f0ba4043a629e7a31927fc4a54f17c3",
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1108694757,
-    "wof:lastmodified":1694492794,
+    "wof:lastmodified":1695886495,
     "wof:name":"Concepcion Quezaltepeque",
     "wof:parent_id":85677193,
     "wof:placetype":"county",

--- a/data/110/869/475/9/1108694759.geojson
+++ b/data/110/869/475/9/1108694759.geojson
@@ -76,6 +76,7 @@
     "wof:concordances":{
         "hasc:id":"SV.SO.CU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493118,
     "wof:geomhash":"267c87bf5fe6408da86defbce77bfd62",
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1108694759,
-    "wof:lastmodified":1694492794,
+    "wof:lastmodified":1695886495,
     "wof:name":"Cuisnahuat",
     "wof:parent_id":85677159,
     "wof:placetype":"county",

--- a/data/110/869/476/1/1108694761.geojson
+++ b/data/110/869/476/1/1108694761.geojson
@@ -89,6 +89,7 @@
     "wof:concordances":{
         "hasc:id":"SV.SS.ME"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493119,
     "wof:geomhash":"43c37d06bb96dbd613bee9322e048288",
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1108694761,
-    "wof:lastmodified":1694492409,
+    "wof:lastmodified":1695886438,
     "wof:name":"Cuscatancingo",
     "wof:parent_id":85677163,
     "wof:placetype":"county",

--- a/data/110/869/476/5/1108694765.geojson
+++ b/data/110/869/476/5/1108694765.geojson
@@ -59,6 +59,7 @@
     "wof:concordances":{
         "hasc:id":"SV.PA.CU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493120,
     "wof:geomhash":"528e8015785eb897a50f2af56a2a7e4c",
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1108694765,
-    "wof:lastmodified":1694492794,
+    "wof:lastmodified":1695886495,
     "wof:name":"Cuyultitan",
     "wof:parent_id":85677155,
     "wof:placetype":"county",

--- a/data/110/869/476/7/1108694767.geojson
+++ b/data/110/869/476/7/1108694767.geojson
@@ -59,6 +59,7 @@
     "wof:concordances":{
         "hasc:id":"SV.MO.DC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493123,
     "wof:geomhash":"bcaa69c3c479e6e8d65b8bb0591e6974",
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1108694767,
-    "wof:lastmodified":1694492794,
+    "wof:lastmodified":1695886495,
     "wof:name":"Delicias De Concepcion",
     "wof:parent_id":85677173,
     "wof:placetype":"county",

--- a/data/110/869/476/9/1108694769.geojson
+++ b/data/110/869/476/9/1108694769.geojson
@@ -59,6 +59,7 @@
     "wof:concordances":{
         "hasc:id":"SV.CH.DN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493125,
     "wof:geomhash":"e7b0dbe4b2aac94352cf18736c20aa5c",
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1108694769,
-    "wof:lastmodified":1694492794,
+    "wof:lastmodified":1695886496,
     "wof:name":"Dulce Nombre De Maria",
     "wof:parent_id":85677193,
     "wof:placetype":"county",

--- a/data/110/869/477/1/1108694771.geojson
+++ b/data/110/869/477/1/1108694771.geojson
@@ -97,6 +97,7 @@
     "wof:concordances":{
         "hasc:id":"SV.UN.EC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493127,
     "wof:geomhash":"093bd3b096176f7e0ac35d0d991dc025",
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1108694771,
-    "wof:lastmodified":1694492409,
+    "wof:lastmodified":1695886438,
     "wof:name":"El Carmen",
     "wof:parent_id":85677169,
     "wof:placetype":"county",

--- a/data/110/869/477/3/1108694773.geojson
+++ b/data/110/869/477/3/1108694773.geojson
@@ -58,6 +58,7 @@
     "wof:concordances":{
         "hasc:id":"SV.CH.EC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493129,
     "wof:geomhash":"38758f8b779fb82ce614cd39f84f5b8f",
@@ -70,7 +71,7 @@
         }
     ],
     "wof:id":1108694773,
-    "wof:lastmodified":1694492794,
+    "wof:lastmodified":1695886496,
     "wof:name":"El Carrizal",
     "wof:parent_id":85677193,
     "wof:placetype":"county",

--- a/data/110/869/477/5/1108694775.geojson
+++ b/data/110/869/477/5/1108694775.geojson
@@ -73,6 +73,7 @@
     "wof:concordances":{
         "hasc:id":"SV.SA.EC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493130,
     "wof:geomhash":"038ff40ebe9b693c1f4fd54a3cf6271d",
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108694775,
-    "wof:lastmodified":1694492794,
+    "wof:lastmodified":1695886496,
     "wof:name":"El Congo",
     "wof:parent_id":85677195,
     "wof:placetype":"county",

--- a/data/110/869/477/7/1108694777.geojson
+++ b/data/110/869/477/7/1108694777.geojson
@@ -76,6 +76,7 @@
     "wof:concordances":{
         "hasc:id":"SV.MO.ED"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493132,
     "wof:geomhash":"501132160728f7d7f3716f5e19b2443c",
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1108694777,
-    "wof:lastmodified":1694492794,
+    "wof:lastmodified":1695886496,
     "wof:name":"El Divisadero",
     "wof:parent_id":85677173,
     "wof:placetype":"county",

--- a/data/110/869/477/9/1108694779.geojson
+++ b/data/110/869/477/9/1108694779.geojson
@@ -76,6 +76,7 @@
     "wof:concordances":{
         "hasc:id":"SV.SS.EL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493134,
     "wof:geomhash":"f6f38595d37a0e10bcc6bcc83a88ecc3",
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1108694779,
-    "wof:lastmodified":1694492794,
+    "wof:lastmodified":1695886496,
     "wof:name":"El Paisnal",
     "wof:parent_id":85677163,
     "wof:placetype":"county",

--- a/data/110/869/478/3/1108694783.geojson
+++ b/data/110/869/478/3/1108694783.geojson
@@ -59,6 +59,7 @@
     "wof:concordances":{
         "hasc:id":"SV.CH.EP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493135,
     "wof:geomhash":"03614a7ad180460b26cb4076fd0d8558",
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1108694783,
-    "wof:lastmodified":1694492795,
+    "wof:lastmodified":1695886496,
     "wof:name":"El Paraiso",
     "wof:parent_id":85677193,
     "wof:placetype":"county",

--- a/data/110/869/478/5/1108694785.geojson
+++ b/data/110/869/478/5/1108694785.geojson
@@ -130,6 +130,7 @@
     "wof:concordances":{
         "hasc:id":"SV.SA.EL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493136,
     "wof:geomhash":"b72fa061f4878ba85b60c450cdaa2b1b",
@@ -142,7 +143,7 @@
         }
     ],
     "wof:id":1108694785,
-    "wof:lastmodified":1694492931,
+    "wof:lastmodified":1695886760,
     "wof:name":"El Porvenir",
     "wof:parent_id":85677195,
     "wof:placetype":"county",

--- a/data/110/869/478/7/1108694787.geojson
+++ b/data/110/869/478/7/1108694787.geojson
@@ -80,6 +80,7 @@
     "wof:concordances":{
         "hasc:id":"SV.AH.AT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493138,
     "wof:geomhash":"ed6c860b9048d929d4f60aa1a1e4f580",
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1108694787,
-    "wof:lastmodified":1694492795,
+    "wof:lastmodified":1695886496,
     "wof:name":"El Refugio",
     "wof:parent_id":85677139,
     "wof:placetype":"county",

--- a/data/110/869/478/9/1108694789.geojson
+++ b/data/110/869/478/9/1108694789.geojson
@@ -97,6 +97,7 @@
     "wof:concordances":{
         "hasc:id":"SV.PA.EL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493141,
     "wof:geomhash":"814daf5fa1ee6c966522e1a95d70759d",
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1108694789,
-    "wof:lastmodified":1694492409,
+    "wof:lastmodified":1695886437,
     "wof:name":"El Rosario",
     "wof:parent_id":85677155,
     "wof:placetype":"county",

--- a/data/110/869/479/1/1108694791.geojson
+++ b/data/110/869/479/1/1108694791.geojson
@@ -97,6 +97,7 @@
     "wof:concordances":{
         "hasc:id":"SV.MO.ER"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493142,
     "wof:geomhash":"0509e3ddd3621e825d58c715c0bf5ef8",
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1108694791,
-    "wof:lastmodified":1694492409,
+    "wof:lastmodified":1695886438,
     "wof:name":"El Rosario",
     "wof:parent_id":85677173,
     "wof:placetype":"county",

--- a/data/110/869/479/3/1108694793.geojson
+++ b/data/110/869/479/3/1108694793.geojson
@@ -73,6 +73,7 @@
     "wof:concordances":{
         "hasc:id":"SV.UN.ES"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493144,
     "wof:geomhash":"fc042c2e058b9b3d783de034d98b24a0",
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108694793,
-    "wof:lastmodified":1694492795,
+    "wof:lastmodified":1695886496,
     "wof:name":"El Sauce",
     "wof:parent_id":85677169,
     "wof:placetype":"county",

--- a/data/110/869/479/5/1108694795.geojson
+++ b/data/110/869/479/5/1108694795.geojson
@@ -59,6 +59,7 @@
     "wof:concordances":{
         "hasc:id":"SV.US.ER"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493148,
     "wof:geomhash":"0cb349129760501d1aad9307245872e8",
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1108694795,
-    "wof:lastmodified":1694492795,
+    "wof:lastmodified":1695886496,
     "wof:name":"Ereguayquin",
     "wof:parent_id":85677187,
     "wof:placetype":"county",

--- a/data/110/869/479/7/1108694797.geojson
+++ b/data/110/869/479/7/1108694797.geojson
@@ -73,6 +73,7 @@
     "wof:concordances":{
         "hasc:id":"SV.CA.GU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493152,
     "wof:geomhash":"e96afbd513d24bd2c250ef292ac9ee3e",
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108694797,
-    "wof:lastmodified":1694492409,
+    "wof:lastmodified":1695886439,
     "wof:name":"Guacotecti",
     "wof:parent_id":85677141,
     "wof:placetype":"county",

--- a/data/110/869/480/1/1108694801.geojson
+++ b/data/110/869/480/1/1108694801.geojson
@@ -163,6 +163,7 @@
     "wof:concordances":{
         "hasc:id":"SV.SV.GU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493153,
     "wof:geomhash":"8b8d160048b09547670e2df4acd3a3ee",
@@ -175,7 +176,7 @@
         }
     ],
     "wof:id":1108694801,
-    "wof:lastmodified":1694492410,
+    "wof:lastmodified":1695886441,
     "wof:name":"Guadalupe",
     "wof:parent_id":85677185,
     "wof:placetype":"county",

--- a/data/110/869/480/3/1108694803.geojson
+++ b/data/110/869/480/3/1108694803.geojson
@@ -73,6 +73,7 @@
     "wof:concordances":{
         "hasc:id":"SV.MO.GL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493155,
     "wof:geomhash":"1576eb623a974853c2977c399af6e81e",
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108694803,
-    "wof:lastmodified":1694492795,
+    "wof:lastmodified":1695886496,
     "wof:name":"Gualococti",
     "wof:parent_id":85677173,
     "wof:placetype":"county",

--- a/data/110/869/480/5/1108694805.geojson
+++ b/data/110/869/480/5/1108694805.geojson
@@ -73,6 +73,7 @@
     "wof:concordances":{
         "hasc:id":"SV.MO.GT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493157,
     "wof:geomhash":"b0677c6ab6f8c6f2062d249db212f8c0",
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108694805,
-    "wof:lastmodified":1694492795,
+    "wof:lastmodified":1695886496,
     "wof:name":"Guatajiagua",
     "wof:parent_id":85677173,
     "wof:placetype":"county",

--- a/data/110/869/480/7/1108694807.geojson
+++ b/data/110/869/480/7/1108694807.geojson
@@ -79,6 +79,7 @@
     "wof:concordances":{
         "hasc:id":"SV.AH.GU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493160,
     "wof:geomhash":"a35c3aee9bb3083b85b1e82b9f5b0b2a",
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108694807,
-    "wof:lastmodified":1694492410,
+    "wof:lastmodified":1695886441,
     "wof:name":"Guaymango",
     "wof:parent_id":85677139,
     "wof:placetype":"county",

--- a/data/110/869/480/9/1108694809.geojson
+++ b/data/110/869/480/9/1108694809.geojson
@@ -79,6 +79,7 @@
     "wof:concordances":{
         "hasc:id":"SV.SS.GU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493162,
     "wof:geomhash":"546a392d5552d516428a682f9097d0ec",
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108694809,
-    "wof:lastmodified":1694492410,
+    "wof:lastmodified":1695886441,
     "wof:name":"Guazapa",
     "wof:parent_id":85677163,
     "wof:placetype":"county",

--- a/data/110/869/481/1/1108694811.geojson
+++ b/data/110/869/481/1/1108694811.geojson
@@ -59,6 +59,7 @@
     "wof:concordances":{
         "hasc:id":"SV.LI.HU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493163,
     "wof:geomhash":"aa040e782438555e6b956e30c21c8ef1",
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1108694811,
-    "wof:lastmodified":1694492795,
+    "wof:lastmodified":1695886496,
     "wof:name":"Huizucar",
     "wof:parent_id":85677151,
     "wof:placetype":"county",

--- a/data/110/869/481/3/1108694813.geojson
+++ b/data/110/869/481/3/1108694813.geojson
@@ -73,6 +73,7 @@
     "wof:concordances":{
         "hasc:id":"SV.LI.JA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493169,
     "wof:geomhash":"5f5e52cf3a9ef0975797efb4a63e23b8",
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108694813,
-    "wof:lastmodified":1694492795,
+    "wof:lastmodified":1695886496,
     "wof:name":"Jayaque",
     "wof:parent_id":85677151,
     "wof:placetype":"county",

--- a/data/110/869/481/5/1108694815.geojson
+++ b/data/110/869/481/5/1108694815.geojson
@@ -59,6 +59,7 @@
     "wof:concordances":{
         "hasc:id":"SV.PA.JE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493171,
     "wof:geomhash":"c28d3389a097b3481d9b078636c7c43d",
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1108694815,
-    "wof:lastmodified":1694492795,
+    "wof:lastmodified":1695886497,
     "wof:name":"Jerusalen",
     "wof:parent_id":85677155,
     "wof:placetype":"county",

--- a/data/110/869/481/9/1108694819.geojson
+++ b/data/110/869/481/9/1108694819.geojson
@@ -73,6 +73,7 @@
     "wof:concordances":{
         "hasc:id":"SV.MO.JT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493173,
     "wof:geomhash":"3796773a48469bdf394b407784e8e86d",
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108694819,
-    "wof:lastmodified":1694492795,
+    "wof:lastmodified":1695886497,
     "wof:name":"Joateca",
     "wof:parent_id":85677173,
     "wof:placetype":"county",

--- a/data/110/869/482/1/1108694821.geojson
+++ b/data/110/869/482/1/1108694821.geojson
@@ -73,6 +73,7 @@
     "wof:concordances":{
         "hasc:id":"SV.US.JP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493178,
     "wof:geomhash":"fa3705d0a18b14b0873cdc5a10359868",
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108694821,
-    "wof:lastmodified":1694492795,
+    "wof:lastmodified":1695886497,
     "wof:name":"Jucuapa",
     "wof:parent_id":85677187,
     "wof:placetype":"county",

--- a/data/110/869/482/3/1108694823.geojson
+++ b/data/110/869/482/3/1108694823.geojson
@@ -106,6 +106,7 @@
     "wof:concordances":{
         "hasc:id":"SV.CA.JU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493184,
     "wof:geomhash":"b8abbb91718603a6a1d9c6ddaa87d6c1",
@@ -118,7 +119,7 @@
         }
     ],
     "wof:id":1108694823,
-    "wof:lastmodified":1694492931,
+    "wof:lastmodified":1695886760,
     "wof:name":"Jutiapa",
     "wof:parent_id":85677141,
     "wof:placetype":"county",

--- a/data/110/869/482/5/1108694825.geojson
+++ b/data/110/869/482/5/1108694825.geojson
@@ -58,6 +58,7 @@
     "wof:concordances":{
         "hasc:id":"SV.CH.LL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493185,
     "wof:geomhash":"ec8046185cbcfab4e7ef68cde2f4c82e",
@@ -70,7 +71,7 @@
         }
     ],
     "wof:id":1108694825,
-    "wof:lastmodified":1694492795,
+    "wof:lastmodified":1695886497,
     "wof:name":"La Laguna",
     "wof:parent_id":85677193,
     "wof:placetype":"county",

--- a/data/110/869/482/7/1108694827.geojson
+++ b/data/110/869/482/7/1108694827.geojson
@@ -130,6 +130,7 @@
     "wof:concordances":{
         "hasc:id":"SV.LI.LL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493187,
     "wof:geomhash":"23c849b951dd7aaa7b1cdf50141f5b54",
@@ -142,7 +143,7 @@
         }
     ],
     "wof:id":1108694827,
-    "wof:lastmodified":1694492931,
+    "wof:lastmodified":1695886760,
     "wof:name":"La Libertad",
     "wof:parent_id":85677151,
     "wof:placetype":"county",

--- a/data/110/869/482/9/1108694829.geojson
+++ b/data/110/869/482/9/1108694829.geojson
@@ -109,6 +109,7 @@
     "wof:concordances":{
         "hasc:id":"SV.CH.LR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493189,
     "wof:geomhash":"61b42362d86e1667586339fedea019fa",
@@ -121,7 +122,7 @@
         }
     ],
     "wof:id":1108694829,
-    "wof:lastmodified":1694492409,
+    "wof:lastmodified":1695886438,
     "wof:name":"La Reina",
     "wof:parent_id":85677193,
     "wof:placetype":"county",

--- a/data/110/869/483/1/1108694831.geojson
+++ b/data/110/869/483/1/1108694831.geojson
@@ -92,6 +92,7 @@
     "wof:concordances":{
         "hasc:id":"SV.CH.SJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493192,
     "wof:geomhash":"250d859da79769074296f5e0a235c73f",
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1108694831,
-    "wof:lastmodified":1694492409,
+    "wof:lastmodified":1695886438,
     "wof:name":"Las Flores",
     "wof:parent_id":85677193,
     "wof:placetype":"county",

--- a/data/110/869/483/3/1108694833.geojson
+++ b/data/110/869/483/3/1108694833.geojson
@@ -82,6 +82,7 @@
     "wof:concordances":{
         "hasc:id":"SV.CH.LV"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493194,
     "wof:geomhash":"1c59ecbd961455b3c0b108c341d136ca",
@@ -94,7 +95,7 @@
         }
     ],
     "wof:id":1108694833,
-    "wof:lastmodified":1694492409,
+    "wof:lastmodified":1695886438,
     "wof:name":"Las Vueltas",
     "wof:parent_id":85677193,
     "wof:placetype":"county",

--- a/data/110/869/483/7/1108694837.geojson
+++ b/data/110/869/483/7/1108694837.geojson
@@ -73,6 +73,7 @@
     "wof:concordances":{
         "hasc:id":"SV.UN.LI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493196,
     "wof:geomhash":"c8f0ff749c0aceb56b7b4c06871c6505",
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108694837,
-    "wof:lastmodified":1694492795,
+    "wof:lastmodified":1695886497,
     "wof:name":"Lislique",
     "wof:parent_id":85677169,
     "wof:placetype":"county",

--- a/data/110/869/483/9/1108694839.geojson
+++ b/data/110/869/483/9/1108694839.geojson
@@ -73,6 +73,7 @@
     "wof:concordances":{
         "hasc:id":"SV.SM.LO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493197,
     "wof:geomhash":"a7dc18be5322d625b11377c895d4181f",
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108694839,
-    "wof:lastmodified":1694492795,
+    "wof:lastmodified":1695886497,
     "wof:name":"Lolotique",
     "wof:parent_id":85677177,
     "wof:placetype":"county",

--- a/data/110/869/484/1/1108694841.geojson
+++ b/data/110/869/484/1/1108694841.geojson
@@ -73,6 +73,7 @@
     "wof:concordances":{
         "hasc:id":"SV.MO.LO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493199,
     "wof:geomhash":"ac78d0ec8060c16c9fcc562a36261e41",
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108694841,
-    "wof:lastmodified":1694492795,
+    "wof:lastmodified":1695886497,
     "wof:name":"Lolotiquillo",
     "wof:parent_id":85677173,
     "wof:placetype":"county",

--- a/data/110/869/484/3/1108694843.geojson
+++ b/data/110/869/484/3/1108694843.geojson
@@ -73,6 +73,7 @@
     "wof:concordances":{
         "hasc:id":"SV.SA.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493200,
     "wof:geomhash":"874831aa19bad3f2ce315fc905dd3f56",
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108694843,
-    "wof:lastmodified":1694492795,
+    "wof:lastmodified":1695886497,
     "wof:name":"Masahuat",
     "wof:parent_id":85677195,
     "wof:placetype":"county",

--- a/data/110/869/484/5/1108694845.geojson
+++ b/data/110/869/484/5/1108694845.geojson
@@ -59,6 +59,7 @@
     "wof:concordances":{
         "hasc:id":"SV.UN.MG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493202,
     "wof:geomhash":"79f167cd5e6c1402ca5a1a24d1e2d17f",
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1108694845,
-    "wof:lastmodified":1694492795,
+    "wof:lastmodified":1695886497,
     "wof:name":"Meanguera Del Golfo",
     "wof:parent_id":85677169,
     "wof:placetype":"county",

--- a/data/110/869/484/7/1108694847.geojson
+++ b/data/110/869/484/7/1108694847.geojson
@@ -73,6 +73,7 @@
     "wof:concordances":{
         "hasc:id":"SV.PA.MC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493206,
     "wof:geomhash":"a06f548b0fe09533fbbba162cf2ee942",
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108694847,
-    "wof:lastmodified":1694492409,
+    "wof:lastmodified":1695886438,
     "wof:name":"Mercedes La Ceiba",
     "wof:parent_id":85677155,
     "wof:placetype":"county",

--- a/data/110/869/484/9/1108694849.geojson
+++ b/data/110/869/484/9/1108694849.geojson
@@ -59,6 +59,7 @@
     "wof:concordances":{
         "hasc:id":"SV.US.MU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493208,
     "wof:geomhash":"dfd8b9314e03b31e5e3396ac5e0261a1",
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1108694849,
-    "wof:lastmodified":1694492795,
+    "wof:lastmodified":1695886497,
     "wof:name":"Mercedes Umana",
     "wof:parent_id":85677187,
     "wof:placetype":"county",

--- a/data/110/869/485/1/1108694851.geojson
+++ b/data/110/869/485/1/1108694851.geojson
@@ -73,6 +73,7 @@
     "wof:concordances":{
         "hasc:id":"SV.SM.MO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493211,
     "wof:geomhash":"97511a125ed15c92a6f61d031e62b99c",
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108694851,
-    "wof:lastmodified":1694492795,
+    "wof:lastmodified":1695886497,
     "wof:name":"Moncagua",
     "wof:parent_id":85677177,
     "wof:placetype":"county",

--- a/data/110/869/485/5/1108694855.geojson
+++ b/data/110/869/485/5/1108694855.geojson
@@ -73,6 +73,7 @@
     "wof:concordances":{
         "hasc:id":"SV.CU.MS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493213,
     "wof:geomhash":"35c7ab3b8b951ba815629ca56faf775c",
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108694855,
-    "wof:lastmodified":1694492795,
+    "wof:lastmodified":1695886497,
     "wof:name":"Monte San Juan",
     "wof:parent_id":85677145,
     "wof:placetype":"county",

--- a/data/110/869/485/7/1108694857.geojson
+++ b/data/110/869/485/7/1108694857.geojson
@@ -73,6 +73,7 @@
     "wof:concordances":{
         "hasc:id":"SV.SO.NL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493215,
     "wof:geomhash":"364fafd401b03dd64543cb60c8a7e1cf",
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108694857,
-    "wof:lastmodified":1694492795,
+    "wof:lastmodified":1695886497,
     "wof:name":"Nahulingo",
     "wof:parent_id":85677159,
     "wof:placetype":"county",

--- a/data/110/869/485/9/1108694859.geojson
+++ b/data/110/869/485/9/1108694859.geojson
@@ -59,6 +59,7 @@
     "wof:concordances":{
         "hasc:id":"SV.CH.NJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493218,
     "wof:geomhash":"dee61d30ee4b313231d6b4d63b7dfebc",
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1108694859,
-    "wof:lastmodified":1694492795,
+    "wof:lastmodified":1695886498,
     "wof:name":"Nombre De Jesus",
     "wof:parent_id":85677193,
     "wof:placetype":"county",

--- a/data/110/869/486/1/1108694861.geojson
+++ b/data/110/869/486/1/1108694861.geojson
@@ -206,6 +206,7 @@
     "wof:concordances":{
         "hasc:id":"SV.UN.PO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493222,
     "wof:geomhash":"fedbc0804925d81ac3521dcdfbac47c6",
@@ -218,7 +219,7 @@
         }
     ],
     "wof:id":1108694861,
-    "wof:lastmodified":1694492931,
+    "wof:lastmodified":1695886760,
     "wof:name":"Nueva Esparta",
     "wof:parent_id":85677169,
     "wof:placetype":"county",

--- a/data/110/869/486/3/1108694863.geojson
+++ b/data/110/869/486/3/1108694863.geojson
@@ -58,6 +58,7 @@
     "wof:concordances":{
         "hasc:id":"SV.US.NG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493224,
     "wof:geomhash":"03d27af82678d16e100580fc1607271b",
@@ -70,7 +71,7 @@
         }
     ],
     "wof:id":1108694863,
-    "wof:lastmodified":1694492795,
+    "wof:lastmodified":1695886498,
     "wof:name":"Nueva Granada",
     "wof:parent_id":85677187,
     "wof:placetype":"county",

--- a/data/110/869/486/5/1108694865.geojson
+++ b/data/110/869/486/5/1108694865.geojson
@@ -74,6 +74,7 @@
     "wof:concordances":{
         "hasc:id":"SV.SM.LO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493225,
     "wof:geomhash":"a67396f86d274486d989f1fcac3f0dfd",
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1108694865,
-    "wof:lastmodified":1694492795,
+    "wof:lastmodified":1695886498,
     "wof:name":"Nueva Guadalupe",
     "wof:parent_id":85677177,
     "wof:placetype":"county",

--- a/data/110/869/486/7/1108694867.geojson
+++ b/data/110/869/486/7/1108694867.geojson
@@ -73,6 +73,7 @@
     "wof:concordances":{
         "hasc:id":"SV.CH.NT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493226,
     "wof:geomhash":"031ed1fd16103ebaa5d6361776543844",
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108694867,
-    "wof:lastmodified":1694492795,
+    "wof:lastmodified":1695886498,
     "wof:name":"Nueva Trinidad",
     "wof:parent_id":85677193,
     "wof:placetype":"county",

--- a/data/110/869/486/9/1108694869.geojson
+++ b/data/110/869/486/9/1108694869.geojson
@@ -59,6 +59,7 @@
     "wof:concordances":{
         "hasc:id":"SV.LI.NC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493228,
     "wof:geomhash":"911f6c7ea5b36b8b6a7f3c618aac1b20",
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1108694869,
-    "wof:lastmodified":1694492795,
+    "wof:lastmodified":1695886498,
     "wof:name":"Nuevo Cuscatlan",
     "wof:parent_id":85677151,
     "wof:placetype":"county",

--- a/data/110/869/487/3/1108694873.geojson
+++ b/data/110/869/487/3/1108694873.geojson
@@ -59,6 +59,7 @@
     "wof:concordances":{
         "hasc:id":"SV.SM.NE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493229,
     "wof:geomhash":"2e675958d9e327e1774102808313033b",
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1108694873,
-    "wof:lastmodified":1694492795,
+    "wof:lastmodified":1695886498,
     "wof:name":"Nuevo Eden De San Juan",
     "wof:parent_id":85677177,
     "wof:placetype":"county",

--- a/data/110/869/487/5/1108694875.geojson
+++ b/data/110/869/487/5/1108694875.geojson
@@ -59,6 +59,7 @@
     "wof:concordances":{
         "hasc:id":"SV.CH.OA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493231,
     "wof:geomhash":"32fa8ae21f3c9238c4ad1b4be9191b52",
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1108694875,
-    "wof:lastmodified":1694492795,
+    "wof:lastmodified":1695886498,
     "wof:name":"Ojos De Agua",
     "wof:parent_id":85677193,
     "wof:placetype":"county",

--- a/data/110/869/487/7/1108694877.geojson
+++ b/data/110/869/487/7/1108694877.geojson
@@ -73,6 +73,7 @@
     "wof:concordances":{
         "hasc:id":"SV.PA.OL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493232,
     "wof:geomhash":"86ad3bd9ae357bfa26e728411c524d67",
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108694877,
-    "wof:lastmodified":1694492410,
+    "wof:lastmodified":1695886440,
     "wof:name":"Olocuilta",
     "wof:parent_id":85677155,
     "wof:placetype":"county",

--- a/data/110/869/487/9/1108694879.geojson
+++ b/data/110/869/487/9/1108694879.geojson
@@ -59,6 +59,7 @@
     "wof:concordances":{
         "hasc:id":"SV.CU.OC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493234,
     "wof:geomhash":"68f0f13cae724180411fd730daf74259",
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1108694879,
-    "wof:lastmodified":1694492795,
+    "wof:lastmodified":1695886498,
     "wof:name":"Oratorio De Concepcion",
     "wof:parent_id":85677145,
     "wof:placetype":"county",

--- a/data/110/869/488/1/1108694881.geojson
+++ b/data/110/869/488/1/1108694881.geojson
@@ -76,6 +76,7 @@
     "wof:concordances":{
         "hasc:id":"SV.MO.OS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493236,
     "wof:geomhash":"d0439f791a12c79469cf8d815676e0ca",
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1108694881,
-    "wof:lastmodified":1694492795,
+    "wof:lastmodified":1695886498,
     "wof:name":"Osicala",
     "wof:parent_id":85677173,
     "wof:placetype":"county",

--- a/data/110/869/488/3/1108694883.geojson
+++ b/data/110/869/488/3/1108694883.geojson
@@ -59,6 +59,7 @@
     "wof:concordances":{
         "hasc:id":"SV.US.OZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493238,
     "wof:geomhash":"176c4f5ff0ab8976b96434a7165ff61a",
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1108694883,
-    "wof:lastmodified":1694492795,
+    "wof:lastmodified":1695886498,
     "wof:name":"Ozatlan",
     "wof:parent_id":85677187,
     "wof:placetype":"county",

--- a/data/110/869/488/5/1108694885.geojson
+++ b/data/110/869/488/5/1108694885.geojson
@@ -76,6 +76,7 @@
     "wof:concordances":{
         "hasc:id":"SV.SS.PA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493240,
     "wof:geomhash":"cbd7708cb28977b9456859e7d913a34c",
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1108694885,
-    "wof:lastmodified":1694492795,
+    "wof:lastmodified":1695886498,
     "wof:name":"Panchimalco",
     "wof:parent_id":85677163,
     "wof:placetype":"county",

--- a/data/110/869/488/7/1108694887.geojson
+++ b/data/110/869/488/7/1108694887.geojson
@@ -59,6 +59,7 @@
     "wof:concordances":{
         "hasc:id":"SV.PA.SE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493241,
     "wof:geomhash":"fe69ea56045efc1b501bdd39762eb94f",
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1108694887,
-    "wof:lastmodified":1694492795,
+    "wof:lastmodified":1695886498,
     "wof:name":"Paraiso De Osorio",
     "wof:parent_id":85677155,
     "wof:placetype":"county",

--- a/data/110/869/489/1/1108694891.geojson
+++ b/data/110/869/489/1/1108694891.geojson
@@ -73,6 +73,7 @@
     "wof:concordances":{
         "hasc:id":"SV.UN.PA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493243,
     "wof:geomhash":"0211472dbaef50e4a5f913cf6317b91f",
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108694891,
-    "wof:lastmodified":1694492410,
+    "wof:lastmodified":1695886441,
     "wof:name":"Pasaquina",
     "wof:parent_id":85677169,
     "wof:placetype":"county",

--- a/data/110/869/489/3/1108694893.geojson
+++ b/data/110/869/489/3/1108694893.geojson
@@ -59,6 +59,7 @@
     "wof:concordances":{
         "hasc:id":"SV.UN.PO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493247,
     "wof:geomhash":"0c31963e19d1994029df9b2e15c5bad8",
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1108694893,
-    "wof:lastmodified":1694492795,
+    "wof:lastmodified":1695886498,
     "wof:name":"Poloros",
     "wof:parent_id":85677169,
     "wof:placetype":"county",

--- a/data/110/869/489/5/1108694895.geojson
+++ b/data/110/869/489/5/1108694895.geojson
@@ -74,6 +74,7 @@
     "wof:concordances":{
         "hasc:id":"SV.CH.PO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493248,
     "wof:geomhash":"3b1af392667ef8b96d4b690c43b86e6b",
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1108694895,
-    "wof:lastmodified":1694492795,
+    "wof:lastmodified":1695886499,
     "wof:name":"Potonico",
     "wof:parent_id":85677193,
     "wof:placetype":"county",

--- a/data/110/869/489/7/1108694897.geojson
+++ b/data/110/869/489/7/1108694897.geojson
@@ -80,6 +80,7 @@
     "wof:concordances":{
         "hasc:id":"SV.US.JI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493249,
     "wof:geomhash":"6dbc7e520bc371f5ca3dd136d99ddfea",
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1108694897,
-    "wof:lastmodified":1694492795,
+    "wof:lastmodified":1695886499,
     "wof:name":"Puerto El Triunfo",
     "wof:parent_id":85677187,
     "wof:placetype":"county",

--- a/data/110/869/489/9/1108694899.geojson
+++ b/data/110/869/489/9/1108694899.geojson
@@ -70,6 +70,7 @@
     "wof:concordances":{
         "hasc:id":"SV.SM.QU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493251,
     "wof:geomhash":"a1f7c95a6061175c2df380e669f16fe9",
@@ -82,7 +83,7 @@
         }
     ],
     "wof:id":1108694899,
-    "wof:lastmodified":1694492795,
+    "wof:lastmodified":1695886499,
     "wof:name":"Quelepa",
     "wof:parent_id":85677177,
     "wof:placetype":"county",

--- a/data/110/869/490/1/1108694901.geojson
+++ b/data/110/869/490/1/1108694901.geojson
@@ -59,6 +59,7 @@
     "wof:concordances":{
         "hasc:id":"SV.SS.RM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493253,
     "wof:geomhash":"ef6363f0d9a3f4acd728596f86ba3809",
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1108694901,
-    "wof:lastmodified":1694492795,
+    "wof:lastmodified":1695886499,
     "wof:name":"Rosario De Mora",
     "wof:parent_id":85677163,
     "wof:placetype":"county",

--- a/data/110/869/490/3/1108694903.geojson
+++ b/data/110/869/490/3/1108694903.geojson
@@ -73,6 +73,7 @@
     "wof:concordances":{
         "hasc:id":"SV.LI.SA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493254,
     "wof:geomhash":"fe1396d414d693eff4045141acbc2c1c",
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108694903,
-    "wof:lastmodified":1694492795,
+    "wof:lastmodified":1695886499,
     "wof:name":"Sacacoyo",
     "wof:parent_id":85677151,
     "wof:placetype":"county",

--- a/data/110/869/490/5/1108694905.geojson
+++ b/data/110/869/490/5/1108694905.geojson
@@ -59,6 +59,7 @@
     "wof:concordances":{
         "hasc:id":"SV.SO.SL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493256,
     "wof:geomhash":"65d9da9bfece731b6f17e38ce5208971",
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1108694905,
-    "wof:lastmodified":1694492795,
+    "wof:lastmodified":1695886499,
     "wof:name":"Salcoatitan",
     "wof:parent_id":85677159,
     "wof:placetype":"county",

--- a/data/110/869/490/9/1108694909.geojson
+++ b/data/110/869/490/9/1108694909.geojson
@@ -59,6 +59,7 @@
     "wof:concordances":{
         "hasc:id":"SV.US.SA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493258,
     "wof:geomhash":"010aaa5587e8a98d184a4d522eb28a78",
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1108694909,
-    "wof:lastmodified":1694492795,
+    "wof:lastmodified":1695886499,
     "wof:name":"San Agustin",
     "wof:parent_id":85677187,
     "wof:placetype":"county",

--- a/data/110/869/491/1/1108694911.geojson
+++ b/data/110/869/491/1/1108694911.geojson
@@ -73,6 +73,7 @@
     "wof:concordances":{
         "hasc:id":"SV.UN.SA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493260,
     "wof:geomhash":"bbbe1191fa92c9ab4087ba16791d152e",
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108694911,
-    "wof:lastmodified":1694492409,
+    "wof:lastmodified":1695886439,
     "wof:name":"San Alejo",
     "wof:parent_id":85677169,
     "wof:placetype":"county",

--- a/data/110/869/491/3/1108694913.geojson
+++ b/data/110/869/491/3/1108694913.geojson
@@ -59,6 +59,7 @@
     "wof:concordances":{
         "hasc:id":"SV.CH.SA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493261,
     "wof:geomhash":"c3e2004ca206bc7526ee7023df79e345",
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1108694913,
-    "wof:lastmodified":1694492795,
+    "wof:lastmodified":1695886499,
     "wof:name":"San Antonio De La Cruz",
     "wof:parent_id":85677193,
     "wof:placetype":"county",

--- a/data/110/869/491/5/1108694915.geojson
+++ b/data/110/869/491/5/1108694915.geojson
@@ -70,6 +70,7 @@
     "wof:concordances":{
         "hasc:id":"SV.CH.SO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493263,
     "wof:geomhash":"5b3237da1d259db961dece2b2cf5f0fa",
@@ -82,7 +83,7 @@
         }
     ],
     "wof:id":1108694915,
-    "wof:lastmodified":1694492795,
+    "wof:lastmodified":1695886499,
     "wof:name":"San Antonio Los Ranchos",
     "wof:parent_id":85677193,
     "wof:placetype":"county",

--- a/data/110/869/491/7/1108694917.geojson
+++ b/data/110/869/491/7/1108694917.geojson
@@ -73,6 +73,7 @@
     "wof:concordances":{
         "hasc:id":"SV.PA.SA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493265,
     "wof:geomhash":"665b3492cac8b7f462a5f3c4ca00c93e",
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108694917,
-    "wof:lastmodified":1694492409,
+    "wof:lastmodified":1695886439,
     "wof:name":"San Antonio Masahuat",
     "wof:parent_id":85677155,
     "wof:placetype":"county",

--- a/data/110/869/491/9/1108694919.geojson
+++ b/data/110/869/491/9/1108694919.geojson
@@ -73,6 +73,7 @@
     "wof:concordances":{
         "hasc:id":"SV.SA.SP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493267,
     "wof:geomhash":"6b17b3566714fbe04abe421c5a30e949",
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108694919,
-    "wof:lastmodified":1694492795,
+    "wof:lastmodified":1695886499,
     "wof:name":"San Antonio Pajonal",
     "wof:parent_id":85677195,
     "wof:placetype":"county",

--- a/data/110/869/492/1/1108694921.geojson
+++ b/data/110/869/492/1/1108694921.geojson
@@ -385,6 +385,7 @@
     "wof:concordances":{
         "hasc:id":"SV.SM.SA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493269,
     "wof:geomhash":"4ba2f76bc6afadaf385af84716931a77",
@@ -397,7 +398,7 @@
         }
     ],
     "wof:id":1108694921,
-    "wof:lastmodified":1694492410,
+    "wof:lastmodified":1695886442,
     "wof:name":"San Antonio",
     "wof:parent_id":85677177,
     "wof:placetype":"county",

--- a/data/110/869/492/3/1108694923.geojson
+++ b/data/110/869/492/3/1108694923.geojson
@@ -59,6 +59,7 @@
     "wof:concordances":{
         "hasc:id":"SV.CU.SB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493270,
     "wof:geomhash":"3832b0463f370b4192291e177e73974e",
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1108694923,
-    "wof:lastmodified":1694492796,
+    "wof:lastmodified":1695886499,
     "wof:name":"San Bartolome Perulapia",
     "wof:parent_id":85677145,
     "wof:placetype":"county",

--- a/data/110/869/492/7/1108694927.geojson
+++ b/data/110/869/492/7/1108694927.geojson
@@ -59,6 +59,7 @@
     "wof:concordances":{
         "hasc:id":"SV.US.SB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493272,
     "wof:geomhash":"1a0162d6f090291daea046a9cdfccb37",
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1108694927,
-    "wof:lastmodified":1694492796,
+    "wof:lastmodified":1695886499,
     "wof:name":"San Buena Ventura",
     "wof:parent_id":85677187,
     "wof:placetype":"county",

--- a/data/110/869/492/9/1108694929.geojson
+++ b/data/110/869/492/9/1108694929.geojson
@@ -73,6 +73,7 @@
     "wof:concordances":{
         "hasc:id":"SV.SV.SY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493276,
     "wof:geomhash":"b4631d5e0b802dc6e621c79ed72bfb14",
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108694929,
-    "wof:lastmodified":1694492796,
+    "wof:lastmodified":1695886499,
     "wof:name":"San Cayetano Istepeque",
     "wof:parent_id":85677185,
     "wof:placetype":"county",

--- a/data/110/869/493/1/1108694931.geojson
+++ b/data/110/869/493/1/1108694931.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"SV.CU.SC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493279,
     "wof:geomhash":"491e0b16c1dddea7465b571f46e9dac8",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108694931,
-    "wof:lastmodified":1694492931,
+    "wof:lastmodified":1695886761,
     "wof:name":"San Cristobal",
     "wof:parent_id":85677145,
     "wof:placetype":"county",

--- a/data/110/869/493/3/1108694933.geojson
+++ b/data/110/869/493/3/1108694933.geojson
@@ -73,6 +73,7 @@
     "wof:concordances":{
         "hasc:id":"SV.PA.SE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493282,
     "wof:geomhash":"83281b07ec6edc8f19d55e65a0778397",
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108694933,
-    "wof:lastmodified":1694492410,
+    "wof:lastmodified":1695886441,
     "wof:name":"San Emigdio",
     "wof:parent_id":85677155,
     "wof:placetype":"county",

--- a/data/110/869/493/5/1108694935.geojson
+++ b/data/110/869/493/5/1108694935.geojson
@@ -73,6 +73,7 @@
     "wof:concordances":{
         "hasc:id":"SV.SV.SE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493284,
     "wof:geomhash":"2700c1f3071c0de96f66ba46b2039e96",
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108694935,
-    "wof:lastmodified":1694492796,
+    "wof:lastmodified":1695886499,
     "wof:name":"San Esteban Catarina",
     "wof:parent_id":85677185,
     "wof:placetype":"county",

--- a/data/110/869/493/7/1108694937.geojson
+++ b/data/110/869/493/7/1108694937.geojson
@@ -172,6 +172,7 @@
     "wof:concordances":{
         "hasc:id":"SV.CH.SD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493285,
     "wof:geomhash":"eb38498e0b74bd414448200e73da546c",
@@ -184,7 +185,7 @@
         }
     ],
     "wof:id":1108694937,
-    "wof:lastmodified":1694492931,
+    "wof:lastmodified":1695886761,
     "wof:name":"San Fernando",
     "wof:parent_id":85677193,
     "wof:placetype":"county",

--- a/data/110/869/493/9/1108694939.geojson
+++ b/data/110/869/493/9/1108694939.geojson
@@ -173,6 +173,7 @@
     "wof:concordances":{
         "hasc:id":"SV.MO.PE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493287,
     "wof:geomhash":"01e2a66759453d60482da4c62f4b3c52",
@@ -185,7 +186,7 @@
         }
     ],
     "wof:id":1108694939,
-    "wof:lastmodified":1694492931,
+    "wof:lastmodified":1695886761,
     "wof:name":"San Fernando",
     "wof:parent_id":85677173,
     "wof:placetype":"county",

--- a/data/110/869/494/1/1108694941.geojson
+++ b/data/110/869/494/1/1108694941.geojson
@@ -73,6 +73,7 @@
     "wof:concordances":{
         "hasc:id":"SV.US.SF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493292,
     "wof:geomhash":"2a063f2c0b62a8bd1d048eb1fecd8c6e",
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108694941,
-    "wof:lastmodified":1694492796,
+    "wof:lastmodified":1695886500,
     "wof:name":"San Francisco Javier",
     "wof:parent_id":85677187,
     "wof:placetype":"county",

--- a/data/110/869/494/5/1108694945.geojson
+++ b/data/110/869/494/5/1108694945.geojson
@@ -73,6 +73,7 @@
     "wof:concordances":{
         "hasc:id":"SV.CH.SF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493294,
     "wof:geomhash":"3c0728fd9d0bf6d3fa367692eb03f08d",
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108694945,
-    "wof:lastmodified":1694492796,
+    "wof:lastmodified":1695886500,
     "wof:name":"San Francisco Lempa",
     "wof:parent_id":85677193,
     "wof:placetype":"county",

--- a/data/110/869/494/7/1108694947.geojson
+++ b/data/110/869/494/7/1108694947.geojson
@@ -59,6 +59,7 @@
     "wof:concordances":{
         "hasc:id":"SV.CH.SZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493297,
     "wof:geomhash":"ebb58dabb4d3505ca1481a305cf43dc8",
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1108694947,
-    "wof:lastmodified":1694492796,
+    "wof:lastmodified":1695886500,
     "wof:name":"San Francisco Morazan",
     "wof:parent_id":85677193,
     "wof:placetype":"county",

--- a/data/110/869/494/9/1108694949.geojson
+++ b/data/110/869/494/9/1108694949.geojson
@@ -73,6 +73,7 @@
     "wof:concordances":{
         "hasc:id":"SV.SM.SG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493302,
     "wof:geomhash":"9858eebe160062379617be077c666ad4",
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108694949,
-    "wof:lastmodified":1694492796,
+    "wof:lastmodified":1695886500,
     "wof:name":"San Gerardo",
     "wof:parent_id":85677177,
     "wof:placetype":"county",

--- a/data/110/869/495/1/1108694951.geojson
+++ b/data/110/869/495/1/1108694951.geojson
@@ -58,6 +58,7 @@
     "wof:concordances":{
         "hasc:id":"SV.SV.SI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493304,
     "wof:geomhash":"1277ccb5dfefc7a033ab91ad390eeb3e",
@@ -70,7 +71,7 @@
         }
     ],
     "wof:id":1108694951,
-    "wof:lastmodified":1694492796,
+    "wof:lastmodified":1695886500,
     "wof:name":"San Ildefonso",
     "wof:parent_id":85677185,
     "wof:placetype":"county",

--- a/data/110/869/495/3/1108694953.geojson
+++ b/data/110/869/495/3/1108694953.geojson
@@ -59,6 +59,7 @@
     "wof:concordances":{
         "hasc:id":"SV.CH.SJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493306,
     "wof:geomhash":"13a07b1092f86181e2c8f88bd032a4e1",
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1108694953,
-    "wof:lastmodified":1694492796,
+    "wof:lastmodified":1695886500,
     "wof:name":"San Isidro Labrador",
     "wof:parent_id":85677193,
     "wof:placetype":"county",

--- a/data/110/869/495/5/1108694955.geojson
+++ b/data/110/869/495/5/1108694955.geojson
@@ -118,6 +118,7 @@
     "wof:concordances":{
         "hasc:id":"SV.CA.SI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493308,
     "wof:geomhash":"4a87170368a3c91e8accafcbf41db13d",
@@ -130,7 +131,7 @@
         }
     ],
     "wof:id":1108694955,
-    "wof:lastmodified":1694492410,
+    "wof:lastmodified":1695886441,
     "wof:name":"San Isidro",
     "wof:parent_id":85677141,
     "wof:placetype":"county",

--- a/data/110/869/495/7/1108694957.geojson
+++ b/data/110/869/495/7/1108694957.geojson
@@ -118,6 +118,7 @@
     "wof:concordances":{
         "hasc:id":"SV.MO.SI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493310,
     "wof:geomhash":"47974d0a70ebf95b0bffa781e81ae7ce",
@@ -130,7 +131,7 @@
         }
     ],
     "wof:id":1108694957,
-    "wof:lastmodified":1694492410,
+    "wof:lastmodified":1695886441,
     "wof:name":"San Isidro",
     "wof:parent_id":85677173,
     "wof:placetype":"county",

--- a/data/110/869/495/9/1108694959.geojson
+++ b/data/110/869/495/9/1108694959.geojson
@@ -59,6 +59,7 @@
     "wof:concordances":{
         "hasc:id":"SV.CU.SJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493313,
     "wof:geomhash":"46ab99d4905b3a42accaef6194dea755",
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1108694959,
-    "wof:lastmodified":1694492796,
+    "wof:lastmodified":1695886500,
     "wof:name":"San Jose Guayabal",
     "wof:parent_id":85677145,
     "wof:placetype":"county",

--- a/data/110/869/496/3/1108694963.geojson
+++ b/data/110/869/496/3/1108694963.geojson
@@ -59,6 +59,7 @@
     "wof:concordances":{
         "hasc:id":"SV.LI.SJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493315,
     "wof:geomhash":"7aa2e200ce906d96c06fa635edd9b354",
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1108694963,
-    "wof:lastmodified":1694492796,
+    "wof:lastmodified":1695886500,
     "wof:name":"San Jose Villanueva",
     "wof:parent_id":85677151,
     "wof:placetype":"county",

--- a/data/110/869/496/5/1108694965.geojson
+++ b/data/110/869/496/5/1108694965.geojson
@@ -98,6 +98,7 @@
     "wof:concordances":{
         "hasc:id":"SV.UN.SJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493317,
     "wof:geomhash":"a842b8488976e3bc5203d51a286eac98",
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1108694965,
-    "wof:lastmodified":1694492931,
+    "wof:lastmodified":1695886760,
     "wof:name":"San Jose",
     "wof:parent_id":85677169,
     "wof:placetype":"county",

--- a/data/110/869/496/7/1108694967.geojson
+++ b/data/110/869/496/7/1108694967.geojson
@@ -59,6 +59,7 @@
     "wof:concordances":{
         "hasc:id":"SV.LI.OP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493319,
     "wof:geomhash":"7ebcdcce2f0a3005450b907f8cc39528",
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1108694967,
-    "wof:lastmodified":1694492796,
+    "wof:lastmodified":1695886500,
     "wof:name":"San Juan Opico",
     "wof:parent_id":85677151,
     "wof:placetype":"county",

--- a/data/110/869/496/9/1108694969.geojson
+++ b/data/110/869/496/9/1108694969.geojson
@@ -76,6 +76,7 @@
     "wof:concordances":{
         "hasc:id":"SV.PA.SU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493321,
     "wof:geomhash":"5e0282c06239daab25da83b0ef4ec801",
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1108694969,
-    "wof:lastmodified":1694492409,
+    "wof:lastmodified":1695886439,
     "wof:name":"San Juan Talpa",
     "wof:parent_id":85677155,
     "wof:placetype":"county",

--- a/data/110/869/497/1/1108694971.geojson
+++ b/data/110/869/497/1/1108694971.geojson
@@ -73,6 +73,7 @@
     "wof:concordances":{
         "hasc:id":"SV.PA.SJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493322,
     "wof:geomhash":"060e20b888da8e5349285827c14ae8ef",
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108694971,
-    "wof:lastmodified":1694492409,
+    "wof:lastmodified":1695886439,
     "wof:name":"San Juan Tepezontes",
     "wof:parent_id":85677155,
     "wof:placetype":"county",

--- a/data/110/869/497/3/1108694973.geojson
+++ b/data/110/869/497/3/1108694973.geojson
@@ -59,6 +59,7 @@
     "wof:concordances":{
         "hasc:id":"SV.SO.SJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493324,
     "wof:geomhash":"1cd3cf9b07f9b99cc59b241c79327622",
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1108694973,
-    "wof:lastmodified":1694492796,
+    "wof:lastmodified":1695886500,
     "wof:name":"San Julian",
     "wof:parent_id":85677159,
     "wof:placetype":"county",

--- a/data/110/869/497/5/1108694975.geojson
+++ b/data/110/869/497/5/1108694975.geojson
@@ -175,6 +175,7 @@
     "wof:concordances":{
         "hasc:id":"SV.AH.SL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493326,
     "wof:geomhash":"dc9c33ac480ba8d3d1f8f5c6105f4cff",
@@ -187,7 +188,7 @@
         }
     ],
     "wof:id":1108694975,
-    "wof:lastmodified":1694492931,
+    "wof:lastmodified":1695886760,
     "wof:name":"San Lorenzo",
     "wof:parent_id":85677139,
     "wof:placetype":"county",

--- a/data/110/869/497/7/1108694977.geojson
+++ b/data/110/869/497/7/1108694977.geojson
@@ -175,6 +175,7 @@
     "wof:concordances":{
         "hasc:id":"SV.SV.SL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493327,
     "wof:geomhash":"5ad266baf7e048280d862c2500db8000",
@@ -187,7 +188,7 @@
         }
     ],
     "wof:id":1108694977,
-    "wof:lastmodified":1694492931,
+    "wof:lastmodified":1695886760,
     "wof:name":"San Lorenzo",
     "wof:parent_id":85677185,
     "wof:placetype":"county",

--- a/data/110/869/498/1/1108694981.geojson
+++ b/data/110/869/498/1/1108694981.geojson
@@ -59,6 +59,7 @@
     "wof:concordances":{
         "hasc:id":"SV.SM.SL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493329,
     "wof:geomhash":"f5ca566ae3fff45dd786a77adcb69d53",
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1108694981,
-    "wof:lastmodified":1694492796,
+    "wof:lastmodified":1695886500,
     "wof:name":"San Luis De La Reina",
     "wof:parent_id":85677177,
     "wof:placetype":"county",

--- a/data/110/869/498/3/1108694983.geojson
+++ b/data/110/869/498/3/1108694983.geojson
@@ -59,6 +59,7 @@
     "wof:concordances":{
         "hasc:id":"SV.CH.SL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493331,
     "wof:geomhash":"325fa0ae88511e5ce36dbbba5ba79979",
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1108694983,
-    "wof:lastmodified":1694492796,
+    "wof:lastmodified":1695886500,
     "wof:name":"San Luis Del Carmen",
     "wof:parent_id":85677193,
     "wof:placetype":"county",

--- a/data/110/869/498/5/1108694985.geojson
+++ b/data/110/869/498/5/1108694985.geojson
@@ -73,6 +73,7 @@
     "wof:concordances":{
         "hasc:id":"SV.PA.SL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493333,
     "wof:geomhash":"2801be7ea9a919cb2998c8ef4cbb8ad7",
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108694985,
-    "wof:lastmodified":1694492409,
+    "wof:lastmodified":1695886439,
     "wof:name":"San Luis Talpa",
     "wof:parent_id":85677155,
     "wof:placetype":"county",

--- a/data/110/869/498/7/1108694987.geojson
+++ b/data/110/869/498/7/1108694987.geojson
@@ -139,6 +139,7 @@
     "wof:concordances":{
         "hasc:id":"SV.SS.SM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493334,
     "wof:geomhash":"e7cd6ff573366391cfc85acf3f05fc26",
@@ -151,7 +152,7 @@
         }
     ],
     "wof:id":1108694987,
-    "wof:lastmodified":1694492931,
+    "wof:lastmodified":1695886760,
     "wof:name":"San Marcos",
     "wof:parent_id":85677163,
     "wof:placetype":"county",

--- a/data/110/869/498/9/1108694989.geojson
+++ b/data/110/869/498/9/1108694989.geojson
@@ -59,6 +59,7 @@
     "wof:concordances":{
         "hasc:id":"SV.CH.SM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493339,
     "wof:geomhash":"d3580cc7ee2c08a8acd3dc4ab037df9a",
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1108694989,
-    "wof:lastmodified":1694492796,
+    "wof:lastmodified":1695886500,
     "wof:name":"San Miguel De Mercedes",
     "wof:parent_id":85677193,
     "wof:placetype":"county",

--- a/data/110/869/499/1/1108694991.geojson
+++ b/data/110/869/499/1/1108694991.geojson
@@ -70,6 +70,7 @@
     "wof:concordances":{
         "hasc:id":"SV.PA.SZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493340,
     "wof:geomhash":"cf513dc169ababbe7317b872ff1c37c1",
@@ -82,7 +83,7 @@
         }
     ],
     "wof:id":1108694991,
-    "wof:lastmodified":1694492409,
+    "wof:lastmodified":1695886439,
     "wof:name":"San Miguel Tepezontes",
     "wof:parent_id":85677155,
     "wof:placetype":"county",

--- a/data/110/869/499/3/1108694993.geojson
+++ b/data/110/869/499/3/1108694993.geojson
@@ -73,6 +73,7 @@
     "wof:concordances":{
         "hasc:id":"SV.LI.SP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493343,
     "wof:geomhash":"8ad01f480f65b54da095da5f79e5fb4e",
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108694993,
-    "wof:lastmodified":1694492796,
+    "wof:lastmodified":1695886500,
     "wof:name":"San Pablo Tacachico",
     "wof:parent_id":85677151,
     "wof:placetype":"county",

--- a/data/110/869/499/5/1108694995.geojson
+++ b/data/110/869/499/5/1108694995.geojson
@@ -73,6 +73,7 @@
     "wof:concordances":{
         "hasc:id":"SV.PA.SM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493344,
     "wof:geomhash":"f3d8d2c7af4db36e2b5b597d8674ae99",
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108694995,
-    "wof:lastmodified":1694492409,
+    "wof:lastmodified":1695886439,
     "wof:name":"San Pedro Masahuat",
     "wof:parent_id":85677155,
     "wof:placetype":"county",

--- a/data/110/869/499/9/1108694999.geojson
+++ b/data/110/869/499/9/1108694999.geojson
@@ -76,6 +76,7 @@
     "wof:concordances":{
         "hasc:id":"SV.PA.SP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493346,
     "wof:geomhash":"786e6c0468f852dff4b884d74074dcb6",
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1108694999,
-    "wof:lastmodified":1694492409,
+    "wof:lastmodified":1695886439,
     "wof:name":"San Pedro Nonualco",
     "wof:parent_id":85677155,
     "wof:placetype":"county",

--- a/data/110/869/500/1/1108695001.geojson
+++ b/data/110/869/500/1/1108695001.geojson
@@ -76,6 +76,7 @@
     "wof:concordances":{
         "hasc:id":"SV.AH.SP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493350,
     "wof:geomhash":"333539f3a7406b8ba9c67b70cc7769de",
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1108695001,
-    "wof:lastmodified":1694492409,
+    "wof:lastmodified":1695886440,
     "wof:name":"San Pedro Puxtla",
     "wof:parent_id":85677139,
     "wof:placetype":"county",

--- a/data/110/869/500/3/1108695003.geojson
+++ b/data/110/869/500/3/1108695003.geojson
@@ -73,6 +73,7 @@
     "wof:concordances":{
         "hasc:id":"SV.CU.SF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493352,
     "wof:geomhash":"d1f9b4f9addbc7e845237fc961a1665f",
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108695003,
-    "wof:lastmodified":1694492796,
+    "wof:lastmodified":1695886500,
     "wof:name":"San Rafael Cedros",
     "wof:parent_id":85677145,
     "wof:placetype":"county",

--- a/data/110/869/500/5/1108695005.geojson
+++ b/data/110/869/500/5/1108695005.geojson
@@ -59,6 +59,7 @@
     "wof:concordances":{
         "hasc:id":"SV.SM.SR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493354,
     "wof:geomhash":"fbb069eeaeeb7fbbc8428783ac5f7336",
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1108695005,
-    "wof:lastmodified":1694492796,
+    "wof:lastmodified":1695886501,
     "wof:name":"San Rafael Oriente",
     "wof:parent_id":85677177,
     "wof:placetype":"county",

--- a/data/110/869/500/7/1108695007.geojson
+++ b/data/110/869/500/7/1108695007.geojson
@@ -139,6 +139,7 @@
     "wof:concordances":{
         "hasc:id":"SV.CH.SR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493356,
     "wof:geomhash":"83c327f7cd3aab6ea6cbbc985c06fb3c",
@@ -151,7 +152,7 @@
         }
     ],
     "wof:id":1108695007,
-    "wof:lastmodified":1694492931,
+    "wof:lastmodified":1695886760,
     "wof:name":"San Rafael",
     "wof:parent_id":85677193,
     "wof:placetype":"county",

--- a/data/110/869/500/9/1108695009.geojson
+++ b/data/110/869/500/9/1108695009.geojson
@@ -119,6 +119,7 @@
     "wof:concordances":{
         "hasc:id":"SV.CU.SR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493358,
     "wof:geomhash":"b9bac0d27fe598645a7255d54cdad825",
@@ -131,7 +132,7 @@
         }
     ],
     "wof:id":1108695009,
-    "wof:lastmodified":1694492931,
+    "wof:lastmodified":1695886761,
     "wof:name":"San Ramon",
     "wof:parent_id":85677145,
     "wof:placetype":"county",

--- a/data/110/869/501/1/1108695011.geojson
+++ b/data/110/869/501/1/1108695011.geojson
@@ -59,6 +59,7 @@
     "wof:concordances":{
         "hasc:id":"SV.SA.SS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493360,
     "wof:geomhash":"372bd1e606b4a81ad9b5916446480e61",
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1108695011,
-    "wof:lastmodified":1694492796,
+    "wof:lastmodified":1695886501,
     "wof:name":"San Sebastian Salitrillo",
     "wof:parent_id":85677195,
     "wof:placetype":"county",

--- a/data/110/869/501/3/1108695013.geojson
+++ b/data/110/869/501/3/1108695013.geojson
@@ -59,6 +59,7 @@
     "wof:concordances":{
         "hasc:id":"SV.SV.SS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493362,
     "wof:geomhash":"a8069b489ef080fd2cb7c40b855bb8eb",
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1108695013,
-    "wof:lastmodified":1694492796,
+    "wof:lastmodified":1695886501,
     "wof:name":"San Sebastian",
     "wof:parent_id":85677185,
     "wof:placetype":"county",

--- a/data/110/869/501/7/1108695017.geojson
+++ b/data/110/869/501/7/1108695017.geojson
@@ -86,6 +86,7 @@
     "wof:concordances":{
         "hasc:id":"SV.MO.SS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493364,
     "wof:geomhash":"ccbf4b00cb85205211aa0d39025375ec",
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1108695017,
-    "wof:lastmodified":1694492409,
+    "wof:lastmodified":1695886440,
     "wof:name":"San Simon",
     "wof:parent_id":85677173,
     "wof:placetype":"county",

--- a/data/110/869/501/9/1108695019.geojson
+++ b/data/110/869/501/9/1108695019.geojson
@@ -139,6 +139,7 @@
     "wof:concordances":{
         "hasc:id":"SV.SV.SV"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493365,
     "wof:geomhash":"ad4c766f441b43e9e2df18aab1e38130",
@@ -151,7 +152,7 @@
         }
     ],
     "wof:id":1108695019,
-    "wof:lastmodified":1694492931,
+    "wof:lastmodified":1695886761,
     "wof:name":"San Vicente",
     "wof:parent_id":85677185,
     "wof:placetype":"county",

--- a/data/110/869/502/1/1108695021.geojson
+++ b/data/110/869/502/1/1108695021.geojson
@@ -73,6 +73,7 @@
     "wof:concordances":{
         "hasc:id":"SV.SO.SC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493368,
     "wof:geomhash":"d7966465a1f2224bb424e6660c216422",
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108695021,
-    "wof:lastmodified":1694492796,
+    "wof:lastmodified":1695886501,
     "wof:name":"Santa Catarina Masahuat",
     "wof:parent_id":85677159,
     "wof:placetype":"county",

--- a/data/110/869/502/3/1108695023.geojson
+++ b/data/110/869/502/3/1108695023.geojson
@@ -166,6 +166,7 @@
     "wof:concordances":{
         "hasc:id":"SV.SV.SC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493369,
     "wof:geomhash":"b4c841eb32a80d21a5da2ffecd80acf8",
@@ -178,7 +179,7 @@
         }
     ],
     "wof:id":1108695023,
-    "wof:lastmodified":1694492409,
+    "wof:lastmodified":1695886437,
     "wof:name":"Santa Clara",
     "wof:parent_id":85677185,
     "wof:placetype":"county",

--- a/data/110/869/502/5/1108695025.geojson
+++ b/data/110/869/502/5/1108695025.geojson
@@ -73,6 +73,7 @@
     "wof:concordances":{
         "hasc:id":"SV.CU.SA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493371,
     "wof:geomhash":"015fdf03419c3990b791569a7ba5d3b8",
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108695025,
-    "wof:lastmodified":1694492796,
+    "wof:lastmodified":1695886501,
     "wof:name":"Santa Cruz Analquito",
     "wof:parent_id":85677145,
     "wof:placetype":"county",

--- a/data/110/869/502/7/1108695027.geojson
+++ b/data/110/869/502/7/1108695027.geojson
@@ -73,6 +73,7 @@
     "wof:concordances":{
         "hasc:id":"SV.CU.SM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493373,
     "wof:geomhash":"448e6bda6fed0a094b73f3bb674e45bd",
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108695027,
-    "wof:lastmodified":1694492796,
+    "wof:lastmodified":1695886501,
     "wof:name":"Santa Cruz Michapa",
     "wof:parent_id":85677145,
     "wof:placetype":"county",

--- a/data/110/869/502/9/1108695029.geojson
+++ b/data/110/869/502/9/1108695029.geojson
@@ -124,6 +124,7 @@
     "wof:concordances":{
         "hasc:id":"SV.US.SE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493375,
     "wof:geomhash":"b75387240619383ec8bca7657dd6e39f",
@@ -136,7 +137,7 @@
         }
     ],
     "wof:id":1108695029,
-    "wof:lastmodified":1694492931,
+    "wof:lastmodified":1695886760,
     "wof:name":"Santa Elena",
     "wof:parent_id":85677187,
     "wof:placetype":"county",

--- a/data/110/869/503/1/1108695031.geojson
+++ b/data/110/869/503/1/1108695031.geojson
@@ -59,6 +59,7 @@
     "wof:concordances":{
         "hasc:id":"SV.SO.SI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493377,
     "wof:geomhash":"a50461e623f61bb9dc13fcfc5cb956fd",
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1108695031,
-    "wof:lastmodified":1694492796,
+    "wof:lastmodified":1695886501,
     "wof:name":"Santa Isabel Ishuatan",
     "wof:parent_id":85677159,
     "wof:placetype":"county",

--- a/data/110/869/503/5/1108695035.geojson
+++ b/data/110/869/503/5/1108695035.geojson
@@ -59,6 +59,7 @@
     "wof:concordances":{
         "hasc:id":"SV.PA.SO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493378,
     "wof:geomhash":"8fa647eb4f4316ac04d373a37c179489",
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1108695035,
-    "wof:lastmodified":1694492796,
+    "wof:lastmodified":1695886501,
     "wof:name":"Santa Maria Ostuma",
     "wof:parent_id":85677155,
     "wof:placetype":"county",

--- a/data/110/869/503/7/1108695037.geojson
+++ b/data/110/869/503/7/1108695037.geojson
@@ -179,6 +179,7 @@
     "wof:concordances":{
         "hasc:id":"SV.US.SM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493380,
     "wof:geomhash":"93ec1677f0745683b99d47d3b0465def",
@@ -191,7 +192,7 @@
         }
     ],
     "wof:id":1108695037,
-    "wof:lastmodified":1694492931,
+    "wof:lastmodified":1695886760,
     "wof:name":"Santa Maria",
     "wof:parent_id":85677187,
     "wof:placetype":"county",

--- a/data/110/869/503/9/1108695039.geojson
+++ b/data/110/869/503/9/1108695039.geojson
@@ -163,6 +163,7 @@
     "wof:concordances":{
         "hasc:id":"SV.CH.ST"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493382,
     "wof:geomhash":"0fe3bd0972e0d2a845159a085f869484",
@@ -175,7 +176,7 @@
         }
     ],
     "wof:id":1108695039,
-    "wof:lastmodified":1694492931,
+    "wof:lastmodified":1695886760,
     "wof:name":"Santa Rita",
     "wof:parent_id":85677193,
     "wof:placetype":"county",

--- a/data/110/869/504/1/1108695041.geojson
+++ b/data/110/869/504/1/1108695041.geojson
@@ -59,6 +59,7 @@
     "wof:concordances":{
         "hasc:id":"SV.UN.SR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493384,
     "wof:geomhash":"6396ee7acbdbf3ef77c9daa61c152a12",
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1108695041,
-    "wof:lastmodified":1694492796,
+    "wof:lastmodified":1695886501,
     "wof:name":"Santa Rosa De Lima",
     "wof:parent_id":85677169,
     "wof:placetype":"county",

--- a/data/110/869/504/3/1108695043.geojson
+++ b/data/110/869/504/3/1108695043.geojson
@@ -59,6 +59,7 @@
     "wof:concordances":{
         "hasc:id":"SV.SA.SR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493385,
     "wof:geomhash":"d872e58990f2aede80eb58d030050971",
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1108695043,
-    "wof:lastmodified":1694492796,
+    "wof:lastmodified":1695886501,
     "wof:name":"Santa Rosa Guachipilin",
     "wof:parent_id":85677195,
     "wof:placetype":"county",

--- a/data/110/869/504/5/1108695045.geojson
+++ b/data/110/869/504/5/1108695045.geojson
@@ -86,6 +86,7 @@
     "wof:concordances":{
         "hasc:id":"SV.LI.NS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493387,
     "wof:geomhash":"39f8ba97847bc41c69dcb1f652559dd6",
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1108695045,
-    "wof:lastmodified":1694492409,
+    "wof:lastmodified":1695886437,
     "wof:name":"Santa Tecla",
     "wof:parent_id":85677151,
     "wof:placetype":"county",

--- a/data/110/869/504/7/1108695047.geojson
+++ b/data/110/869/504/7/1108695047.geojson
@@ -59,6 +59,7 @@
     "wof:concordances":{
         "hasc:id":"SV.SA.SF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493388,
     "wof:geomhash":"4aa19449069ec7e586f91263cc57bb57",
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1108695047,
-    "wof:lastmodified":1694492796,
+    "wof:lastmodified":1695886501,
     "wof:name":"Santiago De La Frontera",
     "wof:parent_id":85677195,
     "wof:placetype":"county",

--- a/data/110/869/504/9/1108695049.geojson
+++ b/data/110/869/504/9/1108695049.geojson
@@ -59,6 +59,7 @@
     "wof:concordances":{
         "hasc:id":"SV.US.SG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493391,
     "wof:geomhash":"2071aeeaa7ea6e986f2d862761bc58f1",
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1108695049,
-    "wof:lastmodified":1694492796,
+    "wof:lastmodified":1695886501,
     "wof:name":"Santiago De Maria",
     "wof:parent_id":85677187,
     "wof:placetype":"county",

--- a/data/110/869/505/3/1108695053.geojson
+++ b/data/110/869/505/3/1108695053.geojson
@@ -76,6 +76,7 @@
     "wof:concordances":{
         "hasc:id":"SV.PA.ST"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493392,
     "wof:geomhash":"ec02d4940304a6ee532ae9e8d91e8417",
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1108695053,
-    "wof:lastmodified":1694492409,
+    "wof:lastmodified":1695886437,
     "wof:name":"Santiago Nonualco",
     "wof:parent_id":85677155,
     "wof:placetype":"county",

--- a/data/110/869/505/5/1108695055.geojson
+++ b/data/110/869/505/5/1108695055.geojson
@@ -59,6 +59,7 @@
     "wof:concordances":{
         "hasc:id":"SV.SO.SD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493394,
     "wof:geomhash":"b1e3b0c1df65e120b3bce1f9f369ccae",
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1108695055,
-    "wof:lastmodified":1694492796,
+    "wof:lastmodified":1695886501,
     "wof:name":"Santo Domingo De Guzman",
     "wof:parent_id":85677159,
     "wof:placetype":"county",

--- a/data/110/869/505/7/1108695057.geojson
+++ b/data/110/869/505/7/1108695057.geojson
@@ -358,6 +358,7 @@
     "wof:concordances":{
         "hasc:id":"SV.SV.SD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493396,
     "wof:geomhash":"e7ffa670c5343c76d7f6a478f1192889",
@@ -370,7 +371,7 @@
         }
     ],
     "wof:id":1108695057,
-    "wof:lastmodified":1694492409,
+    "wof:lastmodified":1695886437,
     "wof:name":"Santo Domingo",
     "wof:parent_id":85677185,
     "wof:placetype":"county",

--- a/data/110/869/505/9/1108695059.geojson
+++ b/data/110/869/505/9/1108695059.geojson
@@ -128,6 +128,7 @@
     "wof:concordances":{
         "hasc:id":"SV.SS.ST"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493397,
     "wof:geomhash":"daa48505e86cc6cb25f55bef8df715b4",
@@ -140,7 +141,7 @@
         }
     ],
     "wof:id":1108695059,
-    "wof:lastmodified":1694492931,
+    "wof:lastmodified":1695886760,
     "wof:name":"Santo Tomas",
     "wof:parent_id":85677163,
     "wof:placetype":"county",

--- a/data/110/869/506/1/1108695061.geojson
+++ b/data/110/869/506/1/1108695061.geojson
@@ -73,6 +73,7 @@
     "wof:concordances":{
         "hasc:id":"SV.MO.SE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493400,
     "wof:geomhash":"6bd3f70c296535a76a68ea5a3e498c58",
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108695061,
-    "wof:lastmodified":1694492796,
+    "wof:lastmodified":1695886501,
     "wof:name":"Sensembra",
     "wof:parent_id":85677173,
     "wof:placetype":"county",

--- a/data/110/869/506/3/1108695063.geojson
+++ b/data/110/869/506/3/1108695063.geojson
@@ -115,6 +115,7 @@
     "wof:concordances":{
         "hasc:id":"SV.CA.SE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493402,
     "wof:geomhash":"b000b311ecb595f477f8834aa9cf9ac3",
@@ -127,7 +128,7 @@
         }
     ],
     "wof:id":1108695063,
-    "wof:lastmodified":1694492931,
+    "wof:lastmodified":1695886761,
     "wof:name":"Sensuntepeque",
     "wof:parent_id":85677141,
     "wof:placetype":"county",

--- a/data/110/869/506/5/1108695065.geojson
+++ b/data/110/869/506/5/1108695065.geojson
@@ -58,6 +58,7 @@
     "wof:concordances":{
         "hasc:id":"SV.MO.SO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493405,
     "wof:geomhash":"93a51b2ca3628c163bab6a024ec1d16a",
@@ -70,7 +71,7 @@
         }
     ],
     "wof:id":1108695065,
-    "wof:lastmodified":1694492796,
+    "wof:lastmodified":1695886501,
     "wof:name":"Sociedad",
     "wof:parent_id":85677173,
     "wof:placetype":"county",

--- a/data/110/869/506/7/1108695067.geojson
+++ b/data/110/869/506/7/1108695067.geojson
@@ -73,6 +73,7 @@
     "wof:concordances":{
         "hasc:id":"SV.LI.TL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493410,
     "wof:geomhash":"28d1582b14decacc2184cbf8028affef",
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108695067,
-    "wof:lastmodified":1694492796,
+    "wof:lastmodified":1695886502,
     "wof:name":"Talnique",
     "wof:parent_id":85677151,
     "wof:placetype":"county",

--- a/data/110/869/507/1/1108695071.geojson
+++ b/data/110/869/507/1/1108695071.geojson
@@ -70,6 +70,7 @@
     "wof:concordances":{
         "hasc:id":"SV.LI.TM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493412,
     "wof:geomhash":"6147be93a69e777f77defd6da98a61c7",
@@ -82,7 +83,7 @@
         }
     ],
     "wof:id":1108695071,
-    "wof:lastmodified":1694492796,
+    "wof:lastmodified":1695886502,
     "wof:name":"Tamanique",
     "wof:parent_id":85677151,
     "wof:placetype":"county",

--- a/data/110/869/507/3/1108695073.geojson
+++ b/data/110/869/507/3/1108695073.geojson
@@ -73,6 +73,7 @@
     "wof:concordances":{
         "hasc:id":"SV.PA.TA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493413,
     "wof:geomhash":"e1839d0eeeb954e3f100f9063d4d4eb7",
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108695073,
-    "wof:lastmodified":1694492409,
+    "wof:lastmodified":1695886440,
     "wof:name":"Tapalhuaca",
     "wof:parent_id":85677155,
     "wof:placetype":"county",

--- a/data/110/869/507/5/1108695075.geojson
+++ b/data/110/869/507/5/1108695075.geojson
@@ -59,6 +59,7 @@
     "wof:concordances":{
         "hasc:id":"SV.US.TE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493415,
     "wof:geomhash":"86d80178870571a5eefb5b201b0a5825",
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1108695075,
-    "wof:lastmodified":1694492796,
+    "wof:lastmodified":1695886502,
     "wof:name":"Tecapan",
     "wof:parent_id":85677187,
     "wof:placetype":"county",

--- a/data/110/869/507/7/1108695077.geojson
+++ b/data/110/869/507/7/1108695077.geojson
@@ -70,6 +70,7 @@
     "wof:concordances":{
         "hasc:id":"SV.SV.TC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493416,
     "wof:geomhash":"790c9da5d1985d8b0d0c4715bbcf0025",
@@ -82,7 +83,7 @@
         }
     ],
     "wof:id":1108695077,
-    "wof:lastmodified":1694492796,
+    "wof:lastmodified":1695886502,
     "wof:name":"Tecoluca",
     "wof:parent_id":85677185,
     "wof:placetype":"county",

--- a/data/110/869/507/9/1108695079.geojson
+++ b/data/110/869/507/9/1108695079.geojson
@@ -70,6 +70,7 @@
     "wof:concordances":{
         "hasc:id":"SV.CH.TE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493419,
     "wof:geomhash":"78333e2d262f2771fdf55df2bec8163f",
@@ -82,7 +83,7 @@
         }
     ],
     "wof:id":1108695079,
-    "wof:lastmodified":1694492796,
+    "wof:lastmodified":1695886502,
     "wof:name":"Tejutla",
     "wof:parent_id":85677193,
     "wof:placetype":"county",

--- a/data/110/869/508/1/1108695081.geojson
+++ b/data/110/869/508/1/1108695081.geojson
@@ -73,6 +73,7 @@
     "wof:concordances":{
         "hasc:id":"SV.LI.TP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493422,
     "wof:geomhash":"dfa161073513a69d47b3c3b1a4e9cecc",
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108695081,
-    "wof:lastmodified":1694492796,
+    "wof:lastmodified":1695886502,
     "wof:name":"Tepecoyo",
     "wof:parent_id":85677151,
     "wof:placetype":"county",

--- a/data/110/869/508/3/1108695083.geojson
+++ b/data/110/869/508/3/1108695083.geojson
@@ -59,6 +59,7 @@
     "wof:concordances":{
         "hasc:id":"SV.SV.TP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493423,
     "wof:geomhash":"e4a380c7b18cc573d479bf6608ff4c8e",
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1108695083,
-    "wof:lastmodified":1694492796,
+    "wof:lastmodified":1695886502,
     "wof:name":"Tepetitan",
     "wof:parent_id":85677185,
     "wof:placetype":"county",

--- a/data/110/869/508/5/1108695085.geojson
+++ b/data/110/869/508/5/1108695085.geojson
@@ -73,6 +73,7 @@
     "wof:concordances":{
         "hasc:id":"SV.MO.TO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493427,
     "wof:geomhash":"30b96d60d81575e174f27d8ead104a5c",
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108695085,
-    "wof:lastmodified":1694492796,
+    "wof:lastmodified":1695886503,
     "wof:name":"Torola",
     "wof:parent_id":85677173,
     "wof:placetype":"county",

--- a/data/110/869/508/9/1108695089.geojson
+++ b/data/110/869/508/9/1108695089.geojson
@@ -428,6 +428,7 @@
     "wof:concordances":{
         "hasc:id":"SV.AH.TU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493429,
     "wof:geomhash":"78b4546e9b2b349fc5bed72ab93d7727",
@@ -440,7 +441,7 @@
         }
     ],
     "wof:id":1108695089,
-    "wof:lastmodified":1694492409,
+    "wof:lastmodified":1695886439,
     "wof:name":"Turin",
     "wof:parent_id":85677139,
     "wof:placetype":"county",

--- a/data/110/869/509/1/1108695091.geojson
+++ b/data/110/869/509/1/1108695091.geojson
@@ -73,6 +73,7 @@
     "wof:concordances":{
         "hasc:id":"SV.SM.UL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493431,
     "wof:geomhash":"75a7d15ff7ad001f1a29c3f5d9005e08",
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108695091,
-    "wof:lastmodified":1694492796,
+    "wof:lastmodified":1695886503,
     "wof:name":"Uluazapa",
     "wof:parent_id":85677177,
     "wof:placetype":"county",

--- a/data/110/869/509/3/1108695093.geojson
+++ b/data/110/869/509/3/1108695093.geojson
@@ -76,6 +76,7 @@
     "wof:concordances":{
         "hasc:id":"SV.SV.VE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493434,
     "wof:geomhash":"bf992e5ede4c517bb7ab1e07b0e6030f",
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1108695093,
-    "wof:lastmodified":1694492796,
+    "wof:lastmodified":1695886503,
     "wof:name":"Verapaz",
     "wof:parent_id":85677185,
     "wof:placetype":"county",

--- a/data/110/869/509/5/1108695095.geojson
+++ b/data/110/869/509/5/1108695095.geojson
@@ -73,6 +73,7 @@
     "wof:concordances":{
         "hasc:id":"SV.MO.YA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493437,
     "wof:geomhash":"840ab37eb80fd757f5746e31b1408612",
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108695095,
-    "wof:lastmodified":1694492796,
+    "wof:lastmodified":1695886503,
     "wof:name":"Yamabal",
     "wof:parent_id":85677173,
     "wof:placetype":"county",

--- a/data/110/869/509/7/1108695097.geojson
+++ b/data/110/869/509/7/1108695097.geojson
@@ -73,6 +73,7 @@
     "wof:concordances":{
         "hasc:id":"SV.UN.YA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493439,
     "wof:geomhash":"3fdaf18e8013438e476ddfc7c7e2dacb",
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108695097,
-    "wof:lastmodified":1694492796,
+    "wof:lastmodified":1695886503,
     "wof:name":"Yayantique",
     "wof:parent_id":85677169,
     "wof:placetype":"county",

--- a/data/110/869/509/9/1108695099.geojson
+++ b/data/110/869/509/9/1108695099.geojson
@@ -59,6 +59,7 @@
     "wof:concordances":{
         "hasc:id":"SV.MO.YO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493441,
     "wof:geomhash":"5dc51fc2b399ee5c603df565ff36e82a",
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1108695099,
-    "wof:lastmodified":1694492796,
+    "wof:lastmodified":1695886503,
     "wof:name":"Yoloaiquin",
     "wof:parent_id":85677173,
     "wof:placetype":"county",

--- a/data/110/869/510/1/1108695101.geojson
+++ b/data/110/869/510/1/1108695101.geojson
@@ -59,6 +59,7 @@
     "wof:concordances":{
         "hasc:id":"SV.UN.YU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493443,
     "wof:geomhash":"491ba0f5624859cf81702d3e26347b47",
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1108695101,
-    "wof:lastmodified":1694492797,
+    "wof:lastmodified":1695886503,
     "wof:name":"Yucuaiquin",
     "wof:parent_id":85677169,
     "wof:placetype":"county",

--- a/data/110/869/510/3/1108695103.geojson
+++ b/data/110/869/510/3/1108695103.geojson
@@ -373,6 +373,7 @@
     "wof:concordances":{
         "hasc:id":"SV.LI.ZA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493445,
     "wof:geomhash":"36a87f571aa288e1cd946b1c2a426171",
@@ -385,7 +386,7 @@
         }
     ],
     "wof:id":1108695103,
-    "wof:lastmodified":1694492409,
+    "wof:lastmodified":1695886439,
     "wof:name":"Zaragoza",
     "wof:parent_id":85677151,
     "wof:placetype":"county",

--- a/data/110/869/510/7/1108695107.geojson
+++ b/data/110/869/510/7/1108695107.geojson
@@ -58,6 +58,7 @@
     "wof:concordances":{
         "hasc:id":"SV.CH.NJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1474493447,
     "wof:geomhash":"31687a955ad37535c3edd679c41750e6",
@@ -70,7 +71,7 @@
         }
     ],
     "wof:id":1108695107,
-    "wof:lastmodified":1694492797,
+    "wof:lastmodified":1695886503,
     "wof:name":"Zona De Demarcacion Limitrofe",
     "wof:parent_id":85677193,
     "wof:placetype":"county",

--- a/data/421/166/707/421166707.geojson
+++ b/data/421/166/707/421166707.geojson
@@ -215,6 +215,7 @@
         "hasc:id":"SV.SA.SA",
         "qs_pg:id":1264061
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459008700,
     "wof:geom_alt":[
@@ -230,7 +231,7 @@
         }
     ],
     "wof:id":421166707,
-    "wof:lastmodified":1694492931,
+    "wof:lastmodified":1695886761,
     "wof:name":"Santa Ana",
     "wof:parent_id":85677195,
     "wof:placetype":"county",

--- a/data/421/167/823/421167823.geojson
+++ b/data/421/167/823/421167823.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007528,
-    "geom:area_square_m":90375830.136069,
+    "geom:area_square_m":90375987.673392,
     "geom:bbox":"-89.784553,13.807114,-89.649368,13.905039",
     "geom:latitude":13.864686,
     "geom:longitude":-89.717846,
@@ -120,12 +120,13 @@
         "qs_pg:id":421487,
         "wd:id":"Q1006979"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459008744,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b7d5825c0006052bcbf51bc7e2e5e12d",
+    "wof:geomhash":"c8296f335d9331e66b8f9d3aaa288ad8",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":421167823,
-    "wof:lastmodified":1690867023,
+    "wof:lastmodified":1695886782,
     "wof:name":"Juayua",
     "wof:parent_id":85677159,
     "wof:placetype":"county",

--- a/data/421/168/319/421168319.geojson
+++ b/data/421/168/319/421168319.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.034067,
-    "geom:area_square_m":409912944.120798,
+    "geom:area_square_m":409912203.083654,
     "geom:bbox":"-88.813218,13.210808,-88.507467,13.470877",
     "geom:latitude":13.321924,
     "geom:longitude":-88.664091,
@@ -114,12 +114,13 @@
         "qs_pg:id":1119683,
         "wd:id":"Q1154953"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459008761,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"48e85eb9c3713b68666bfd5d885bcca6",
+    "wof:geomhash":"ca945d100b1b5fd42ccb802c495a5e1b",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":421168319,
-    "wof:lastmodified":1690867017,
+    "wof:lastmodified":1695886782,
     "wof:name":"Jiquilisco",
     "wof:parent_id":85677187,
     "wof:placetype":"county",

--- a/data/421/169/323/421169323.geojson
+++ b/data/421/169/323/421169323.geojson
@@ -110,6 +110,7 @@
         "hasc:id":"SV.AH.AH",
         "qs_pg:id":1204174
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459008804,
     "wof:geom_alt":[
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":421169323,
-    "wof:lastmodified":1694492498,
+    "wof:lastmodified":1695886782,
     "wof:name":"Ahuachapan",
     "wof:parent_id":85677139,
     "wof:placetype":"county",

--- a/data/421/169/439/421169439.geojson
+++ b/data/421/169/439/421169439.geojson
@@ -135,6 +135,7 @@
         "qs_pg:id":219085,
         "wd:id":"Q682226"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459008810,
     "wof:geom_alt":[
@@ -150,7 +151,7 @@
         }
     ],
     "wof:id":421169439,
-    "wof:lastmodified":1694492498,
+    "wof:lastmodified":1695886783,
     "wof:name":"Izalco",
     "wof:parent_id":85677159,
     "wof:placetype":"county",

--- a/data/421/170/965/421170965.geojson
+++ b/data/421/170/965/421170965.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005381,
-    "geom:area_square_m":64695682.881109,
+    "geom:area_square_m":64695494.724295,
     "geom:bbox":"-88.945471,13.399005,-88.855834,13.602283",
     "geom:latitude":13.497086,
     "geom:longitude":-88.906596,
@@ -120,12 +120,13 @@
         "qs_pg:id":1203861,
         "wd:id":"Q647944"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459008876,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"57ac041947612594e6e1bbafc79dbf94",
+    "wof:geomhash":"c56641cc9bf89f02b0d3b4e1ce359f3c",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":421170965,
-    "wof:lastmodified":1690867044,
+    "wof:lastmodified":1695886784,
     "wof:name":"San Juan Nonualco",
     "wof:parent_id":85677155,
     "wof:placetype":"county",

--- a/data/421/171/699/421171699.geojson
+++ b/data/421/171/699/421171699.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006944,
-    "geom:area_square_m":83472677.840996,
+    "geom:area_square_m":83473067.988764,
     "geom:bbox":"-89.499764,13.491901,-89.43,13.651996",
     "geom:latitude":13.561792,
     "geom:longitude":-89.462771,
@@ -111,12 +111,13 @@
         "qs_pg:id":1264027,
         "wd:id":"Q3674712"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459008904,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"337887a43d88074d0a4ee94bf4919639",
+    "wof:geomhash":"15abae12df8d60725ee0700bf3ec5f6f",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":421171699,
-    "wof:lastmodified":1690867054,
+    "wof:lastmodified":1695886784,
     "wof:name":"Chiltiupan",
     "wof:parent_id":85677151,
     "wof:placetype":"county",

--- a/data/421/171/701/421171701.geojson
+++ b/data/421/171/701/421171701.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004147,
-    "geom:area_square_m":49855636.556067,
+    "geom:area_square_m":49855344.415969,
     "geom:bbox":"-89.552657,13.49325,-89.482599,13.580369",
     "geom:latitude":13.532197,
     "geom:longitude":-89.5144,
@@ -105,12 +105,13 @@
         "qs_pg:id":1264028,
         "wd:id":"Q3808267"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459008904,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"64653b3f672b5e88c1360c50bea36fda",
+    "wof:geomhash":"98d009df0aa0ef4e58bb279b2d64be82",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -120,7 +121,7 @@
         }
     ],
     "wof:id":421171701,
-    "wof:lastmodified":1690867054,
+    "wof:lastmodified":1695886784,
     "wof:name":"Jicalapa",
     "wof:parent_id":85677151,
     "wof:placetype":"county",

--- a/data/421/171/703/421171703.geojson
+++ b/data/421/171/703/421171703.geojson
@@ -107,6 +107,7 @@
         "hasc:id":"SV.LI.QU",
         "qs_pg:id":1264037
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459008904,
     "wof:geom_alt":[
@@ -122,7 +123,7 @@
         }
     ],
     "wof:id":421171703,
-    "wof:lastmodified":1694492795,
+    "wof:lastmodified":1695886498,
     "wof:name":"Quezaltepeque",
     "wof:parent_id":85677151,
     "wof:placetype":"county",

--- a/data/421/171/705/421171705.geojson
+++ b/data/421/171/705/421171705.geojson
@@ -147,6 +147,7 @@
         "hasc:id":"SV.LI.SM",
         "qs_pg:id":1264038
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459008904,
     "wof:geom_alt":[
@@ -162,7 +163,7 @@
         }
     ],
     "wof:id":421171705,
-    "wof:lastmodified":1694492931,
+    "wof:lastmodified":1695886762,
     "wof:name":"San Matias",
     "wof:parent_id":85677151,
     "wof:placetype":"county",

--- a/data/421/171/709/421171709.geojson
+++ b/data/421/171/709/421171709.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.057784,
-    "geom:area_square_m":692328356.394477,
+    "geom:area_square_m":692328031.509486,
     "geom:bbox":"-89.592813,14.164992,-89.247718,14.450557",
     "geom:latitude":14.314233,
     "geom:longitude":-89.424589,
@@ -129,12 +129,13 @@
         "qs_pg:id":1264063,
         "wd:id":"Q2537220"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459008904,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"28fd6773e6e493c4defe1340a85392df",
+    "wof:geomhash":"c3caf5aa1e2b684b994f0ae7387af7d6",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -144,7 +145,7 @@
         }
     ],
     "wof:id":421171709,
-    "wof:lastmodified":1690867054,
+    "wof:lastmodified":1695886784,
     "wof:name":"Metapan",
     "wof:parent_id":85677195,
     "wof:placetype":"county",

--- a/data/421/172/529/421172529.geojson
+++ b/data/421/172/529/421172529.geojson
@@ -122,6 +122,7 @@
         "hasc:id":"SV.CU.EC",
         "qs_pg:id":1313069
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459008946,
     "wof:geom_alt":[
@@ -137,7 +138,7 @@
         }
     ],
     "wof:id":421172529,
-    "wof:lastmodified":1694492498,
+    "wof:lastmodified":1695886783,
     "wof:name":"El Carmen",
     "wof:parent_id":85677145,
     "wof:placetype":"county",

--- a/data/421/172/531/421172531.geojson
+++ b/data/421/172/531/421172531.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00755,
-    "geom:area_square_m":90891062.441054,
+    "geom:area_square_m":90890904.992634,
     "geom:bbox":"-88.092368,13.162281,-87.98,13.255145",
     "geom:latitude":13.203889,
     "geom:longitude":-88.035345,
@@ -189,12 +189,13 @@
         "qs_pg:id":1313070,
         "wd:id":"Q3800717"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459008946,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"547e11be2e1812c30169b4327129780d",
+    "wof:geomhash":"c3a9ba4cded73a4236de09866934281d",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -204,7 +205,7 @@
         }
     ],
     "wof:id":421172531,
-    "wof:lastmodified":1690867032,
+    "wof:lastmodified":1695886783,
     "wof:name":"Intipuca",
     "wof:parent_id":85677169,
     "wof:placetype":"county",

--- a/data/421/172/669/421172669.geojson
+++ b/data/421/172/669/421172669.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002309,
-    "geom:area_square_m":27736316.416623,
+    "geom:area_square_m":27736407.692839,
     "geom:bbox":"-88.978113,13.690757,-88.907655,13.756636",
     "geom:latitude":13.719249,
     "geom:longitude":-88.940851,
@@ -207,12 +207,13 @@
         "qs_pg:id":1316115,
         "wd:id":"Q2565407"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459008950,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"da156fc0687e8f9459325fd7f6c6dead",
+    "wof:geomhash":"40baa9b146a0b14b15b9c61ef555cdbd",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -222,7 +223,7 @@
         }
     ],
     "wof:id":421172669,
-    "wof:lastmodified":1690867032,
+    "wof:lastmodified":1695886761,
     "wof:name":"Cojutepeque",
     "wof:parent_id":85677145,
     "wof:placetype":"county",

--- a/data/421/172/671/421172671.geojson
+++ b/data/421/172/671/421172671.geojson
@@ -113,6 +113,7 @@
         "hasc:id":"SV.MO.CO",
         "qs_pg:id":1316116
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459008950,
     "wof:geom_alt":[
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":421172671,
-    "wof:lastmodified":1694492498,
+    "wof:lastmodified":1695886783,
     "wof:name":"Corinto",
     "wof:parent_id":85677173,
     "wof:placetype":"county",

--- a/data/421/175/389/421175389.geojson
+++ b/data/421/175/389/421175389.geojson
@@ -247,6 +247,7 @@
         "hasc:id":"SV.CH.LP",
         "qs_pg:id":368920
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459009065,
     "wof:geom_alt":[
@@ -262,7 +263,7 @@
         }
     ],
     "wof:id":421175389,
-    "wof:lastmodified":1694492931,
+    "wof:lastmodified":1695886761,
     "wof:name":"La Palma",
     "wof:parent_id":85677193,
     "wof:placetype":"county",

--- a/data/421/175/391/421175391.geojson
+++ b/data/421/175/391/421175391.geojson
@@ -118,6 +118,7 @@
         "hasc:id":"SV.CU.SU",
         "qs_pg:id":368921
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459009065,
     "wof:geom_alt":[
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":421175391,
-    "wof:lastmodified":1694492796,
+    "wof:lastmodified":1695886502,
     "wof:name":"Suchitoto",
     "wof:parent_id":85677145,
     "wof:placetype":"county",

--- a/data/421/176/713/421176713.geojson
+++ b/data/421/176/713/421176713.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016037,
-    "geom:area_square_m":192651044.441302,
+    "geom:area_square_m":192650897.605184,
     "geom:bbox":"-88.513527,13.638504,-88.302577,13.78039",
     "geom:latitude":13.708836,
     "geom:longitude":-88.389401,
@@ -111,12 +111,13 @@
         "qs_pg:id":392748,
         "wd:id":"Q3958151"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459009117,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b1b1a080a79a2e11277086208ff7b428",
+    "wof:geomhash":"3925b17207c15624bedb1c98b9c326ea",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":421176713,
-    "wof:lastmodified":1690867053,
+    "wof:lastmodified":1695886784,
     "wof:name":"Sesori",
     "wof:parent_id":85677177,
     "wof:placetype":"county",

--- a/data/421/177/967/421177967.geojson
+++ b/data/421/177/967/421177967.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.02877,
-    "geom:area_square_m":345007450.169786,
+    "geom:area_square_m":345008002.458917,
     "geom:bbox":"-89.432884,14.026016,-89.148356,14.249847",
     "geom:latitude":14.109762,
     "geom:longitude":-89.306492,
@@ -114,12 +114,13 @@
         "qs_pg:id":19973,
         "wd:id":"Q2779443"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459009166,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a5419e06a1eeb291a2fa6f2a462deba3",
+    "wof:geomhash":"87fa10277e8d93f0efbab4dc6c2cc011",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":421177967,
-    "wof:lastmodified":1690867044,
+    "wof:lastmodified":1695886784,
     "wof:name":"Nueva Concepcion",
     "wof:parent_id":85677193,
     "wof:placetype":"county",

--- a/data/421/180/175/421180175.geojson
+++ b/data/421/180/175/421180175.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001685,
-    "geom:area_square_m":20239994.614662,
+    "geom:area_square_m":20239909.171738,
     "geom:bbox":"-89.261906,13.72,-89.193645,13.757978",
     "geom:latitude":13.738879,
     "geom:longitude":-89.224477,
@@ -147,12 +147,13 @@
         "qs_pg:id":467294,
         "wd:id":"Q723411"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459009247,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"bcd882091a685ea8c6020f61b3be69ad",
+    "wof:geomhash":"bedaba5ee7885e4ea1dec60a2deb407d",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -162,7 +163,7 @@
         }
     ],
     "wof:id":421180175,
-    "wof:lastmodified":1690867028,
+    "wof:lastmodified":1695886783,
     "wof:name":"Mejicanos",
     "wof:parent_id":85677163,
     "wof:placetype":"county",

--- a/data/421/180/907/421180907.geojson
+++ b/data/421/180/907/421180907.geojson
@@ -397,6 +397,7 @@
         "hasc:id":"SV.SS.SS",
         "qs_pg:id":467283
     },
+    "wof:concordances_official":"hasc:id",
     "wof:coterminous":[
         421191785
     ],
@@ -415,7 +416,7 @@
         }
     ],
     "wof:id":421180907,
-    "wof:lastmodified":1694492931,
+    "wof:lastmodified":1695886761,
     "wof:name":"San Salvador",
     "wof:parent_id":85677163,
     "wof:placetype":"county",

--- a/data/421/180/913/421180913.geojson
+++ b/data/421/180/913/421180913.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000269,
-    "geom:area_square_m":3225435.84764,
+    "geom:area_square_m":3225439.738314,
     "geom:bbox":"-89.220756,13.745795,-89.194673,13.763967",
     "geom:latitude":13.756462,
     "geom:longitude":-89.206027,
@@ -120,12 +120,13 @@
         "qs_pg:id":467293,
         "wd:id":"Q793367"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459009275,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"07d648dfd44f05c56e3adf877b1e4cf2",
+    "wof:geomhash":"30599e5d69e6e835010c9b8cf20cc938",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":421180913,
-    "wof:lastmodified":1690867029,
+    "wof:lastmodified":1695886783,
     "wof:name":"Ayutuxtepeque",
     "wof:parent_id":85677163,
     "wof:placetype":"county",

--- a/data/421/182/403/421182403.geojson
+++ b/data/421/182/403/421182403.geojson
@@ -289,6 +289,7 @@
         "hasc:id":"SV.CA.VI",
         "qs_pg:id":911523
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459009328,
     "wof:geom_alt":[
@@ -304,7 +305,7 @@
         }
     ],
     "wof:id":421182403,
-    "wof:lastmodified":1694492931,
+    "wof:lastmodified":1695886762,
     "wof:name":"Victoria",
     "wof:parent_id":85677141,
     "wof:placetype":"county",

--- a/data/421/183/079/421183079.geojson
+++ b/data/421/183/079/421183079.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004386,
-    "geom:area_square_m":52663416.393173,
+    "geom:area_square_m":52663391.19157,
     "geom:bbox":"-89.251329,13.751009,-89.149708,13.85142",
     "geom:latitude":13.798952,
     "geom:longitude":-89.196092,
@@ -213,12 +213,13 @@
         "qs_pg:id":961140,
         "wd:id":"Q619646"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459009357,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3b5023453dbbf8b42278ea00fd2a87d5",
+    "wof:geomhash":"806ff916b6fbf63ed6423c973274333b",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -228,7 +229,7 @@
         }
     ],
     "wof:id":421183079,
-    "wof:lastmodified":1690867045,
+    "wof:lastmodified":1695886784,
     "wof:name":"Apopa",
     "wof:parent_id":85677163,
     "wof:placetype":"county",

--- a/data/421/183/081/421183081.geojson
+++ b/data/421/183/081/421183081.geojson
@@ -113,6 +113,7 @@
         "hasc:id":"SV.SS.CU",
         "qs_pg:id":961141
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459009357,
     "wof:geom_alt":[
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":421183081,
-    "wof:lastmodified":1694492498,
+    "wof:lastmodified":1695886784,
     "wof:name":"Delgado",
     "wof:parent_id":85677163,
     "wof:placetype":"county",

--- a/data/421/183/185/421183185.geojson
+++ b/data/421/183/185/421183185.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00584,
-    "geom:area_square_m":70079532.207313,
+    "geom:area_square_m":70079548.668561,
     "geom:bbox":"-88.174713,13.895289,-88.072631,13.999649",
     "geom:latitude":13.949637,
     "geom:longitude":-88.114709,
@@ -111,12 +111,13 @@
         "qs_pg:id":969549,
         "wd:id":"Q3621256"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459009361,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"57f49bd29c0a71fbf44c0d454636ae76",
+    "wof:geomhash":"cae27df3d664f741595a821e59308bdb",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":421183185,
-    "wof:lastmodified":1690867046,
+    "wof:lastmodified":1695886784,
     "wof:name":"Arambala",
     "wof:parent_id":85677173,
     "wof:placetype":"county",

--- a/data/421/184/405/421184405.geojson
+++ b/data/421/184/405/421184405.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.019879,
-    "geom:area_square_m":238659894.041449,
+    "geom:area_square_m":238659804.500673,
     "geom:bbox":"-88.922457,13.767793,-88.736292,13.934696",
     "geom:latitude":13.84575,
     "geom:longitude":-88.817532,
@@ -189,12 +189,13 @@
         "qs_pg:id":995774,
         "wd:id":"Q2779383"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459009409,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ad0dedc80ad645ea337e3a8090655922",
+    "wof:geomhash":"b91000f9856c441ede73830a2b05135d",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -204,7 +205,7 @@
         }
     ],
     "wof:id":421184405,
-    "wof:lastmodified":1690867043,
+    "wof:lastmodified":1695886784,
     "wof:name":"Ilobasco",
     "wof:parent_id":85677141,
     "wof:placetype":"county",

--- a/data/421/184/407/421184407.geojson
+++ b/data/421/184/407/421184407.geojson
@@ -97,6 +97,7 @@
         "hasc:id":"SV.US.ES",
         "qs_pg:id":995775
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459009409,
     "wof:geom_alt":[
@@ -112,7 +113,7 @@
         }
     ],
     "wof:id":421184407,
-    "wof:lastmodified":1694492795,
+    "wof:lastmodified":1695886496,
     "wof:name":"Estanzuelas",
     "wof:parent_id":85677187,
     "wof:placetype":"county",

--- a/data/421/184/409/421184409.geojson
+++ b/data/421/184/409/421184409.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01909,
-    "geom:area_square_m":229797775.126997,
+    "geom:area_square_m":229797768.432688,
     "geom:bbox":"-88.370095,13.159667,-88.124637,13.311809",
     "geom:latitude":13.218968,
     "geom:longitude":-88.248699,
@@ -189,12 +189,13 @@
         "qs_pg:id":995776,
         "wd:id":"Q1154960"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459009409,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"96395f97ea3b7a04d305003f51f0da4b",
+    "wof:geomhash":"d6ace1f54f6518acf86ecf3a378b3449",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -204,7 +205,7 @@
         }
     ],
     "wof:id":421184409,
-    "wof:lastmodified":1690867042,
+    "wof:lastmodified":1695886784,
     "wof:name":"Jucuaran",
     "wof:parent_id":85677187,
     "wof:placetype":"county",

--- a/data/421/184/607/421184607.geojson
+++ b/data/421/184/607/421184607.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005159,
-    "geom:area_square_m":61908476.526421,
+    "geom:area_square_m":61908130.433486,
     "geom:bbox":"-89.791389,13.898289,-89.701549,14.014539",
     "geom:latitude":13.959346,
     "geom:longitude":-89.741882,
@@ -192,12 +192,13 @@
         "qs_pg:id":1002236,
         "wd:id":"Q2779447"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459009416,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"047cfd896a5cf9554bf10aca126d374d",
+    "wof:geomhash":"ea8dd25a05065563bff45046d47b824d",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -207,7 +208,7 @@
         }
     ],
     "wof:id":421184607,
-    "wof:lastmodified":1690867043,
+    "wof:lastmodified":1695886784,
     "wof:name":"Atiquizaya",
     "wof:parent_id":85677139,
     "wof:placetype":"county",

--- a/data/421/184/721/421184721.geojson
+++ b/data/421/184/721/421184721.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006926,
-    "geom:area_square_m":83327619.357033,
+    "geom:area_square_m":83327667.893501,
     "geom:bbox":"-88.35646,13.250981,-88.242573,13.39089",
     "geom:latitude":13.337031,
     "geom:longitude":-88.295606,
@@ -189,12 +189,13 @@
         "qs_pg:id":1003289,
         "wd:id":"Q1157240"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459009420,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4ae27a5cb2cc80a2ac5b4413a474ac26",
+    "wof:geomhash":"95281d612b56e8ae9703938beabf699d",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -204,7 +205,7 @@
         }
     ],
     "wof:id":421184721,
-    "wof:lastmodified":1690867043,
+    "wof:lastmodified":1695886784,
     "wof:name":"El Transito",
     "wof:parent_id":85677177,
     "wof:placetype":"county",

--- a/data/421/184/831/421184831.geojson
+++ b/data/421/184/831/421184831.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017883,
-    "geom:area_square_m":214917766.016113,
+    "geom:area_square_m":214917815.625459,
     "geom:bbox":"-89.805204,13.523185,-89.629402,13.740462",
     "geom:latitude":13.607633,
     "geom:longitude":-89.730335,
@@ -219,12 +219,13 @@
         "qs_pg:id":1119679,
         "wd:id":"Q1014248"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459009423,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c03ea9a1b15a5d14fb1d1fe61fa470d0",
+    "wof:geomhash":"b26df76d40b5870feb9360b362ffe4b7",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -234,7 +235,7 @@
         }
     ],
     "wof:id":421184831,
-    "wof:lastmodified":1690867042,
+    "wof:lastmodified":1695886762,
     "wof:name":"Sonsonate",
     "wof:parent_id":85677159,
     "wof:placetype":"county",

--- a/data/421/185/175/421185175.geojson
+++ b/data/421/185/175/421185175.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006579,
-    "geom:area_square_m":79068085.81705,
+    "geom:area_square_m":79067986.072759,
     "geom:bbox":"-88.058508,13.564637,-87.957811,13.676459",
     "geom:latitude":13.617602,
     "geom:longitude":-88.014186,
@@ -111,12 +111,13 @@
         "qs_pg:id":1019041,
         "wd:id":"Q3808621"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459009434,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d6a35081098f7b6f54af1b2ffc35ff94",
+    "wof:geomhash":"1a9846d576f61c3f8c78bf2d21880091",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":421185175,
-    "wof:lastmodified":1690867055,
+    "wof:lastmodified":1695886784,
     "wof:name":"Jocoro",
     "wof:parent_id":85677173,
     "wof:placetype":"county",

--- a/data/421/185/233/421185233.geojson
+++ b/data/421/185/233/421185233.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00082,
-    "geom:area_square_m":9865456.471031,
+    "geom:area_square_m":9865456.810124,
     "geom:bbox":"-88.937797,13.465375,-88.909141,13.512687",
     "geom:latitude":13.487648,
     "geom:longitude":-88.922898,
@@ -108,12 +108,13 @@
         "qs_pg:id":1019916,
         "wd:id":"Q1154783"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459009436,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a3baf2aa034d1d56ccf2d1436b40c2d6",
+    "wof:geomhash":"2ea70d185d6b6acd2cf6b2b493ff86df",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -123,7 +124,7 @@
         }
     ],
     "wof:id":421185233,
-    "wof:lastmodified":1690867055,
+    "wof:lastmodified":1695886784,
     "wof:name":"San Rafael Obrajuelo",
     "wof:parent_id":85677155,
     "wof:placetype":"county",

--- a/data/421/186/439/421186439.geojson
+++ b/data/421/186/439/421186439.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003228,
-    "geom:area_square_m":38749766.97812,
+    "geom:area_square_m":38749729.444033,
     "geom:bbox":"-89.834091,13.809167,-89.765786,13.89118",
     "geom:latitude":13.85296,
     "geom:longitude":-89.80037,
@@ -120,12 +120,13 @@
         "qs_pg:id":1068969,
         "wd:id":"Q2779422"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459009481,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"faa089960763ee22452fe8e6a596c43c",
+    "wof:geomhash":"ea2d4f92fb7257ebd6ed622b2621209b",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":421186439,
-    "wof:lastmodified":1690867033,
+    "wof:lastmodified":1695886784,
     "wof:name":"Apaneca",
     "wof:parent_id":85677139,
     "wof:placetype":"county",

--- a/data/421/188/901/421188901.geojson
+++ b/data/421/188/901/421188901.geojson
@@ -94,6 +94,7 @@
         "qs_pg:id":1104970,
         "wd:id":"Q1123798"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459009587,
     "wof:geom_alt":[
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":421188901,
-    "wof:lastmodified":1694492794,
+    "wof:lastmodified":1695886495,
     "wof:name":"Concepcion De Ataco",
     "wof:parent_id":85677139,
     "wof:placetype":"county",

--- a/data/421/189/127/421189127.geojson
+++ b/data/421/189/127/421189127.geojson
@@ -159,6 +159,7 @@
         "hasc:id":"SV.LI.CL",
         "qs_pg:id":1110201
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459009605,
     "wof:geom_alt":[
@@ -174,7 +175,7 @@
         }
     ],
     "wof:id":421189127,
-    "wof:lastmodified":1694492498,
+    "wof:lastmodified":1695886783,
     "wof:name":"Colon",
     "wof:parent_id":85677151,
     "wof:placetype":"county",

--- a/data/421/189/131/421189131.geojson
+++ b/data/421/189/131/421189131.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006908,
-    "geom:area_square_m":83018580.67416,
+    "geom:area_square_m":83018158.04709,
     "geom:bbox":"-89.408835,13.532057,-89.328774,13.679446",
     "geom:latitude":13.604783,
     "geom:longitude":-89.364046,
@@ -111,12 +111,13 @@
         "qs_pg:id":1110211,
         "wd:id":"Q3683966"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459009605,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"62b4b24033155577b04f8055a75404b4",
+    "wof:geomhash":"acd8fe15ecdd304a2365d611c7b96aed",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":421189131,
-    "wof:lastmodified":1690867031,
+    "wof:lastmodified":1695886783,
     "wof:name":"Comasagua",
     "wof:parent_id":85677151,
     "wof:placetype":"county",

--- a/data/421/189/133/421189133.geojson
+++ b/data/421/189/133/421189133.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002855,
-    "geom:area_square_m":34300871.449006,
+    "geom:area_square_m":34300774.95275,
     "geom:bbox":"-89.134562,13.669997,-89.045834,13.723384",
     "geom:latitude":13.692211,
     "geom:longitude":-89.095604,
@@ -144,12 +144,13 @@
         "qs_pg:id":1110212,
         "wd:id":"Q1659066"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459009606,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ab030544a4479b42ac58c87cf2694fea",
+    "wof:geomhash":"670298af504b7419f263222016a943f1",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -159,7 +160,7 @@
         }
     ],
     "wof:id":421189133,
-    "wof:lastmodified":1690867031,
+    "wof:lastmodified":1695886783,
     "wof:name":"Ilopango",
     "wof:parent_id":85677163,
     "wof:placetype":"county",

--- a/data/421/189/135/421189135.geojson
+++ b/data/421/189/135/421189135.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006909,
-    "geom:area_square_m":82947604.997173,
+    "geom:area_square_m":82947460.214065,
     "geom:bbox":"-89.268002,13.744956,-89.179433,13.922028",
     "geom:latitude":13.840589,
     "geom:longitude":-89.224917,
@@ -126,12 +126,13 @@
         "qs_pg:id":1110213,
         "wd:id":"Q1003551"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459009611,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ccd82e23834269d7fccee848e72bdf4d",
+    "wof:geomhash":"6156e18ca417015102e942e1c2349085",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":421189135,
-    "wof:lastmodified":1690867030,
+    "wof:lastmodified":1695886783,
     "wof:name":"Nejapa",
     "wof:parent_id":85677163,
     "wof:placetype":"county",

--- a/data/421/189/151/421189151.geojson
+++ b/data/421/189/151/421189151.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004478,
-    "geom:area_square_m":53797665.325963,
+    "geom:area_square_m":53797500.158565,
     "geom:bbox":"-89.682255,13.654835,-89.596261,13.739967",
     "geom:latitude":13.703989,
     "geom:longitude":-89.636696,
@@ -111,12 +111,13 @@
         "qs_pg:id":1110221,
         "wd:id":"Q985418"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459009611,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"271675545bcab4cc939991ed8d2f6f92",
+    "wof:geomhash":"5558c99095f33864bcc0d12967ddb896",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":421189151,
-    "wof:lastmodified":1690867031,
+    "wof:lastmodified":1695886783,
     "wof:name":"Caluco",
     "wof:parent_id":85677159,
     "wof:placetype":"county",

--- a/data/421/189/495/421189495.geojson
+++ b/data/421/189/495/421189495.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005923,
-    "geom:area_square_m":71166662.050227,
+    "geom:area_square_m":71166513.131735,
     "geom:bbox":"-88.137107,13.550612,-88.046403,13.71956",
     "geom:latitude":13.661033,
     "geom:longitude":-88.086525,
@@ -117,12 +117,13 @@
         "qs_pg:id":1113830,
         "wd:id":"Q3947126"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459009627,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"27a387e8b0e1ef17e6beb8bb49d51d9d",
+    "wof:geomhash":"3051844f557bc9faa38234becc03acce",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":421189495,
-    "wof:lastmodified":1690867031,
+    "wof:lastmodified":1695886761,
     "wof:name":"San Francisco Gotera",
     "wof:parent_id":85677173,
     "wof:placetype":"county",

--- a/data/421/189/499/421189499.geojson
+++ b/data/421/189/499/421189499.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007332,
-    "geom:area_square_m":88059610.024251,
+    "geom:area_square_m":88059528.241421,
     "geom:bbox":"-89.049961,13.683153,-88.974108,13.857877",
     "geom:latitude":13.769466,
     "geom:longitude":-89.014696,
@@ -114,12 +114,13 @@
         "qs_pg:id":1113831,
         "wd:id":"Q657154"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459009627,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3d13c3845640ddea6bcf608983954f9a",
+    "wof:geomhash":"d15b3a7d46db97ab3237b36960ad0a49",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":421189499,
-    "wof:lastmodified":1690867031,
+    "wof:lastmodified":1695886783,
     "wof:name":"San Pedro Perulapan",
     "wof:parent_id":85677145,
     "wof:placetype":"county",

--- a/data/421/189/501/421189501.geojson
+++ b/data/421/189/501/421189501.geojson
@@ -116,6 +116,7 @@
         "hasc:id":"SV.SM.SJ",
         "qs_pg:id":1113832
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459009627,
     "wof:geom_alt":[
@@ -131,7 +132,7 @@
         }
     ],
     "wof:id":421189501,
-    "wof:lastmodified":1694492796,
+    "wof:lastmodified":1695886499,
     "wof:name":"San Jorge",
     "wof:parent_id":85677177,
     "wof:placetype":"county",

--- a/data/421/190/155/421190155.geojson
+++ b/data/421/190/155/421190155.geojson
@@ -107,6 +107,7 @@
         "hasc:id":"SV.SA.CO",
         "qs_pg:id":115543
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459009648,
     "wof:geom_alt":[
@@ -122,7 +123,7 @@
         }
     ],
     "wof:id":421190155,
-    "wof:lastmodified":1694492794,
+    "wof:lastmodified":1695886495,
     "wof:name":"Coatepeque",
     "wof:parent_id":85677195,
     "wof:placetype":"county",

--- a/data/421/190/511/421190511.geojson
+++ b/data/421/190/511/421190511.geojson
@@ -121,6 +121,7 @@
         "qs_pg:id":1119678,
         "wd:id":"Q1154656"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459009660,
     "wof:geom_alt":[
@@ -136,7 +137,7 @@
         }
     ],
     "wof:id":421190511,
-    "wof:lastmodified":1694492794,
+    "wof:lastmodified":1695886494,
     "wof:name":"Candelaria De La Frontera",
     "wof:parent_id":85677195,
     "wof:placetype":"county",

--- a/data/421/190/525/421190525.geojson
+++ b/data/421/190/525/421190525.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003384,
-    "geom:area_square_m":40628445.345027,
+    "geom:area_square_m":40628418.809727,
     "geom:bbox":"-88.949586,13.816245,-88.867713,13.90029",
     "geom:latitude":13.85806,
     "geom:longitude":-88.91674,
@@ -108,12 +108,13 @@
         "qs_pg:id":1119688,
         "wd:id":"Q1154062"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459009660,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0b568b6b8437a089b21ae967e3d534a2",
+    "wof:geomhash":"3620d9f82e326bd0ee97af879f0ec75d",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -123,7 +124,7 @@
         }
     ],
     "wof:id":421190525,
-    "wof:lastmodified":1690867039,
+    "wof:lastmodified":1695886784,
     "wof:name":"Tejutepeque",
     "wof:parent_id":85677141,
     "wof:placetype":"county",

--- a/data/421/191/203/421191203.geojson
+++ b/data/421/191/203/421191203.geojson
@@ -143,8 +143,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":26808568,
+        "meso:local_id":"25",
         "qs_pg:id":61155
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"SV",
     "wof:created":1459009684,
     "wof:geom_alt":[
@@ -160,7 +162,7 @@
         }
     ],
     "wof:id":421191203,
-    "wof:lastmodified":1694492931,
+    "wof:lastmodified":1695886761,
     "wof:name":"San Ignacio",
     "wof:parent_id":85677193,
     "wof:placetype":"county",

--- a/data/421/191/205/421191205.geojson
+++ b/data/421/191/205/421191205.geojson
@@ -119,6 +119,7 @@
         "hasc:id":"SV.CH.CH",
         "qs_pg:id":61158
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459009684,
     "wof:geom_alt":[
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":421191205,
-    "wof:lastmodified":1694492931,
+    "wof:lastmodified":1695886762,
     "wof:name":"Chalatenango",
     "wof:parent_id":85677193,
     "wof:placetype":"county",

--- a/data/421/191/209/421191209.geojson
+++ b/data/421/191/209/421191209.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005754,
-    "geom:area_square_m":68923778.75607,
+    "geom:area_square_m":68923746.191172,
     "geom:bbox":"-89.333244,14.328925,-89.175,14.415878",
     "geom:latitude":14.37225,
     "geom:longitude":-89.259725,
@@ -108,12 +108,13 @@
         "qs_pg:id":61159,
         "wd:id":"Q1154046"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459009684,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f185aad0c884adc2514e2cb28dd030bf",
+    "wof:geomhash":"8ec7ff133a462ebc5b0e0c7807e917e8",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -123,7 +124,7 @@
         }
     ],
     "wof:id":421191209,
-    "wof:lastmodified":1690867037,
+    "wof:lastmodified":1695886784,
     "wof:name":"Citala",
     "wof:parent_id":85677193,
     "wof:placetype":"county",

--- a/data/421/191/211/421191211.geojson
+++ b/data/421/191/211/421191211.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006253,
-    "geom:area_square_m":75082476.411255,
+    "geom:area_square_m":75082336.018544,
     "geom:bbox":"-89.466796,13.756675,-89.377461,13.876075",
     "geom:latitude":13.814003,
     "geom:longitude":-89.423796,
@@ -114,12 +114,13 @@
         "qs_pg:id":61160,
         "wd:id":"Q649241"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459009684,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d43609968cb022491ad29616ff95d297",
+    "wof:geomhash":"5b43314128dd10ff46cf1b38a363e34a",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":421191211,
-    "wof:lastmodified":1690867035,
+    "wof:lastmodified":1695886784,
     "wof:name":"Ciudad Arce",
     "wof:parent_id":85677151,
     "wof:placetype":"county",

--- a/data/421/191/215/421191215.geojson
+++ b/data/421/191/215/421191215.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00881,
-    "geom:area_square_m":105897713.424781,
+    "geom:area_square_m":105897529.91392,
     "geom:bbox":"-89.629423,13.499861,-89.474062,13.660776",
     "geom:latitude":13.576626,
     "geom:longitude":-89.540766,
@@ -117,12 +117,13 @@
         "qs_pg:id":61162,
         "wd:id":"Q3984168"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459009684,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fcf150c52c2d30ae570b5dc48cc3dba3",
+    "wof:geomhash":"5302969c94ae4969b89955de5d7479d9",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":421191215,
-    "wof:lastmodified":1690867037,
+    "wof:lastmodified":1695886502,
     "wof:name":"Teotepeque",
     "wof:parent_id":85677151,
     "wof:placetype":"county",

--- a/data/421/191/217/421191217.geojson
+++ b/data/421/191/217/421191217.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.024015,
-    "geom:area_square_m":288828230.226062,
+    "geom:area_square_m":288828902.028275,
     "geom:bbox":"-88.926601,13.267469,-88.78,13.594574",
     "geom:latitude":13.433205,
     "geom:longitude":-88.849393,
@@ -177,12 +177,13 @@
         "qs_pg:id":61163,
         "wd:id":"Q139248"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459009684,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"89f53f3945b1305c924510889788414f",
+    "wof:geomhash":"6591a67d36cc9b5129b64c28c711bc9d",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -192,7 +193,7 @@
         }
     ],
     "wof:id":421191217,
-    "wof:lastmodified":1690867036,
+    "wof:lastmodified":1695886761,
     "wof:name":"Zacatecoluca",
     "wof:parent_id":85677155,
     "wof:placetype":"county",

--- a/data/421/191/219/421191219.geojson
+++ b/data/421/191/219/421191219.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004074,
-    "geom:area_square_m":48965636.566311,
+    "geom:area_square_m":48965759.0049,
     "geom:bbox":"-89.111991,13.562963,-89.032938,13.66732",
     "geom:latitude":13.612864,
     "geom:longitude":-89.0718,
@@ -111,12 +111,13 @@
         "qs_pg:id":61169,
         "wd:id":"Q978154"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459009684,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2c55a079f545ddbc0ddb6c4f223746e3",
+    "wof:geomhash":"94f45353c31cfe25732eafcbdd200514",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":421191219,
-    "wof:lastmodified":1690867036,
+    "wof:lastmodified":1695886784,
     "wof:name":"San Francisco Chinameca",
     "wof:parent_id":85677155,
     "wof:placetype":"county",

--- a/data/421/191/221/421191221.geojson
+++ b/data/421/191/221/421191221.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.014256,
-    "geom:area_square_m":171568821.343368,
+    "geom:area_square_m":171569143.875936,
     "geom:bbox":"-87.943173,13.198699,-87.792016,13.367954",
     "geom:latitude":13.278449,
     "geom:longitude":-87.880983,
@@ -111,12 +111,13 @@
         "qs_pg:id":61188,
         "wd:id":"Q3686207"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459009684,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0465792e82221fe247757fe188d22253",
+    "wof:geomhash":"d86c91be6fc72a56021cdb2fc509d29f",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":421191221,
-    "wof:lastmodified":1690867036,
+    "wof:lastmodified":1695886784,
     "wof:name":"Conchagua",
     "wof:parent_id":85677169,
     "wof:placetype":"county",

--- a/data/421/191/227/421191227.geojson
+++ b/data/421/191/227/421191227.geojson
@@ -189,6 +189,7 @@
         "hasc:id":"SV.UN.LU",
         "qs_pg:id":61190
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459009684,
     "wof:geom_alt":[
@@ -204,7 +205,7 @@
         }
     ],
     "wof:id":421191227,
-    "wof:lastmodified":1694492931,
+    "wof:lastmodified":1695886761,
     "wof:name":"La Union",
     "wof:parent_id":85677169,
     "wof:placetype":"county",

--- a/data/421/191/471/421191471.geojson
+++ b/data/421/191/471/421191471.geojson
@@ -104,6 +104,7 @@
         "hasc:id":"SV.CU.TE",
         "qs_pg:id":1137330
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459009694,
     "wof:geom_alt":[
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":421191471,
-    "wof:lastmodified":1694492796,
+    "wof:lastmodified":1695886502,
     "wof:name":"Tenancingo",
     "wof:parent_id":85677145,
     "wof:placetype":"county",

--- a/data/421/191/473/421191473.geojson
+++ b/data/421/191/473/421191473.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002568,
-    "geom:area_square_m":30823127.913506,
+    "geom:area_square_m":30823220.359213,
     "geom:bbox":"-88.199801,13.875525,-88.130416,13.934256",
     "geom:latitude":13.903064,
     "geom:longitude":-88.162854,
@@ -105,12 +105,13 @@
         "qs_pg:id":1137335,
         "wd:id":"Q3808619"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459009694,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4b6724f405f9e5d4f8f7033d477645bf",
+    "wof:geomhash":"83e3abacc1462ea3f2b1cefd31f8e885",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -120,7 +121,7 @@
         }
     ],
     "wof:id":421191473,
-    "wof:lastmodified":1690867037,
+    "wof:lastmodified":1695886784,
     "wof:name":"Jocoaitique",
     "wof:parent_id":85677173,
     "wof:placetype":"county",

--- a/data/421/191/475/421191475.geojson
+++ b/data/421/191/475/421191475.geojson
@@ -82,6 +82,7 @@
         "hasc:id":"SV.MO.ME",
         "qs_pg:id":1137336
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459009694,
     "wof:geom_alt":[
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":421191475,
-    "wof:lastmodified":1694492795,
+    "wof:lastmodified":1695886496,
     "wof:name":"Meanguera",
     "wof:parent_id":85677173,
     "wof:placetype":"county",

--- a/data/421/191/479/421191479.geojson
+++ b/data/421/191/479/421191479.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001705,
-    "geom:area_square_m":20463785.681165,
+    "geom:area_square_m":20463751.323846,
     "geom:bbox":"-88.181762,13.937241,-88.080476,13.996852",
     "geom:latitude":13.969726,
     "geom:longitude":-88.152393,
@@ -111,12 +111,13 @@
         "qs_pg:id":1137337,
         "wd:id":"Q3900071"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459009694,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"05243053408d61522918c61c9cfdacd0",
+    "wof:geomhash":"dbfc5c9a97ead6a291dde099bd2e4954",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":421191479,
-    "wof:lastmodified":1690867036,
+    "wof:lastmodified":1695886784,
     "wof:name":"Perquin",
     "wof:parent_id":85677173,
     "wof:placetype":"county",

--- a/data/421/193/371/421193371.geojson
+++ b/data/421/193/371/421193371.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012996,
-    "geom:area_square_m":155989407.122965,
+    "geom:area_square_m":155989456.770678,
     "geom:bbox":"-90.038,13.786554,-89.880916,13.967576",
     "geom:latitude":13.895541,
     "geom:longitude":-89.950844,
@@ -126,12 +126,13 @@
         "qs_pg:id":891809,
         "wd:id":"Q1283898"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459009769,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e6e07bb23a81d8de93ea6cdc1203982c",
+    "wof:geomhash":"d56f3daa6676dd78ffa4ae39930e662f",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":421193371,
-    "wof:lastmodified":1690867022,
+    "wof:lastmodified":1695886783,
     "wof:name":"Tacuba",
     "wof:parent_id":85677139,
     "wof:placetype":"county",

--- a/data/421/195/553/421195553.geojson
+++ b/data/421/195/553/421195553.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001869,
-    "geom:area_square_m":22459244.244087,
+    "geom:area_square_m":22459120.043512,
     "geom:bbox":"-89.279086,13.637608,-89.222854,13.71102",
     "geom:latitude":13.673943,
     "geom:longitude":-89.251248,
@@ -123,12 +123,13 @@
         "qs_pg:id":115474,
         "wd:id":"Q575756"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459009852,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5f37214e801374303072baddb5a4605d",
+    "wof:geomhash":"68efeff65588ab5c0b476c309cd27089",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":421195553,
-    "wof:lastmodified":1690867020,
+    "wof:lastmodified":1695886783,
     "wof:name":"Antiguo Cuscatlan",
     "wof:parent_id":85677151,
     "wof:placetype":"county",

--- a/data/421/195/555/421195555.geojson
+++ b/data/421/195/555/421195555.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009679,
-    "geom:area_square_m":116243125.182089,
+    "geom:area_square_m":116243374.288502,
     "geom:bbox":"-88.373043,13.681454,-88.220066,13.815883",
     "geom:latitude":13.757946,
     "geom:longitude":-88.290641,
@@ -129,12 +129,13 @@
         "qs_pg:id":115528,
         "wd:id":"Q1157078"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459009852,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d177a642cb200ac46af0ebbb60804d58",
+    "wof:geomhash":"1b7cfc5cb4bb77747e5921e1017fc2db",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -144,7 +145,7 @@
         }
     ],
     "wof:id":421195555,
-    "wof:lastmodified":1690867019,
+    "wof:lastmodified":1695886783,
     "wof:name":"Ciudad Barrios",
     "wof:parent_id":85677177,
     "wof:placetype":"county",

--- a/data/421/195/557/421195557.geojson
+++ b/data/421/195/557/421195557.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002326,
-    "geom:area_square_m":27943899.046425,
+    "geom:area_square_m":27943839.755512,
     "geom:bbox":"-89.783131,13.68003,-89.724059,13.748555",
     "geom:latitude":13.716329,
     "geom:longitude":-89.752409,
@@ -108,12 +108,13 @@
         "qs_pg:id":115545,
         "wd:id":"Q3946809"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459009852,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a77e6c1f4794f3644560cccd0192254c",
+    "wof:geomhash":"b608f85136787b447a3af5171b64c69f",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -123,7 +124,7 @@
         }
     ],
     "wof:id":421195557,
-    "wof:lastmodified":1690867019,
+    "wof:lastmodified":1695886783,
     "wof:name":"San Antonio Del Monte",
     "wof:parent_id":85677159,
     "wof:placetype":"county",

--- a/data/421/197/065/421197065.geojson
+++ b/data/421/197/065/421197065.geojson
@@ -152,6 +152,7 @@
         "hasc:id":"SV.CA.DO",
         "qs_pg:id":233713
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459009901,
     "wof:geom_alt":[
@@ -167,7 +168,7 @@
         }
     ],
     "wof:id":421197065,
-    "wof:lastmodified":1694492931,
+    "wof:lastmodified":1695886762,
     "wof:name":"Dolores",
     "wof:parent_id":85677141,
     "wof:placetype":"county",

--- a/data/421/201/175/421201175.geojson
+++ b/data/421/201/175/421201175.geojson
@@ -197,6 +197,7 @@
         "hasc:id":"SV.SM.SM",
         "qs_pg:id":210251
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459010064,
     "wof:geom_alt":[
@@ -212,7 +213,7 @@
         }
     ],
     "wof:id":421201175,
-    "wof:lastmodified":1694492931,
+    "wof:lastmodified":1695886762,
     "wof:name":"San Miguel",
     "wof:parent_id":85677177,
     "wof:placetype":"county",

--- a/data/421/201/523/421201523.geojson
+++ b/data/421/201/523/421201523.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000374,
-    "geom:area_square_m":4490188.499992,
+    "geom:area_square_m":4490184.384336,
     "geom:bbox":"-89.723392,13.735091,-89.699764,13.763569",
     "geom:latitude":13.746824,
     "geom:longitude":-89.709252,
@@ -126,12 +126,13 @@
         "qs_pg:id":773146,
         "wd:id":"Q2287976"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459010075,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"02094f3f63c45b944ff1c5b9b44b85dd",
+    "wof:geomhash":"3a79f97e214c1f6860a42ecdc92b6c4b",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":421201523,
-    "wof:lastmodified":1690867042,
+    "wof:lastmodified":1695886784,
     "wof:name":"Sonzacate",
     "wof:parent_id":85677159,
     "wof:placetype":"county",

--- a/data/421/203/377/421203377.geojson
+++ b/data/421/203/377/421203377.geojson
@@ -125,6 +125,7 @@
         "hasc:id":"SV.CU.ER",
         "qs_pg:id":61164
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459010149,
     "wof:geom_alt":[
@@ -140,7 +141,7 @@
         }
     ],
     "wof:id":421203377,
-    "wof:lastmodified":1694492498,
+    "wof:lastmodified":1695886783,
     "wof:name":"El Rosario",
     "wof:parent_id":85677145,
     "wof:placetype":"county",

--- a/data/421/203/589/421203589.geojson
+++ b/data/421/203/589/421203589.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.02236,
-    "geom:area_square_m":268491469.16567,
+    "geom:area_square_m":268491472.63621,
     "geom:bbox":"-90.133533,13.701444,-89.931265,13.905165",
     "geom:latitude":13.808078,
     "geom:longitude":-90.032865,
@@ -129,12 +129,13 @@
         "qs_pg:id":233705,
         "wd:id":"Q766174"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459010157,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fe7750f4dfbc85bca6a86476e344a13e",
+    "wof:geomhash":"93462cd69d6a53a2395f9667ed2c000f",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -144,7 +145,7 @@
         }
     ],
     "wof:id":421203589,
-    "wof:lastmodified":1690867026,
+    "wof:lastmodified":1695886783,
     "wof:name":"San Francisco Menendez",
     "wof:parent_id":85677139,
     "wof:placetype":"county",

--- a/data/421/203/593/421203593.geojson
+++ b/data/421/203/593/421203593.geojson
@@ -104,6 +104,7 @@
         "hasc:id":"SV.US.SD",
         "qs_pg:id":233707
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459010157,
     "wof:geom_alt":[
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":421203593,
-    "wof:lastmodified":1694492498,
+    "wof:lastmodified":1695886783,
     "wof:name":"San Dionisio",
     "wof:parent_id":85677187,
     "wof:placetype":"county",

--- a/data/421/203/731/421203731.geojson
+++ b/data/421/203/731/421203731.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01839,
-    "geom:area_square_m":221326400.478769,
+    "geom:area_square_m":221326723.913514,
     "geom:bbox":"-88.227854,13.166222,-88.031279,13.332476",
     "geom:latitude":13.261918,
     "geom:longitude":-88.129866,
@@ -186,12 +186,13 @@
         "qs_pg:id":115529,
         "wd:id":"Q3675145"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459010161,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3ea94694b19deacaf1c59ed9f4526436",
+    "wof:geomhash":"184799aaf6b707d709ee2800e5fc1010",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -201,7 +202,7 @@
         }
     ],
     "wof:id":421203731,
-    "wof:lastmodified":1690867025,
+    "wof:lastmodified":1695886783,
     "wof:name":"Chirilagua",
     "wof:parent_id":85677177,
     "wof:placetype":"county",

--- a/data/421/203/733/421203733.geojson
+++ b/data/421/203/733/421203733.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002545,
-    "geom:area_square_m":30574896.087754,
+    "geom:area_square_m":30574833.217831,
     "geom:bbox":"-89.171819,13.664226,-89.114679,13.745313",
     "geom:latitude":13.703771,
     "geom:longitude":-89.143343,
@@ -162,12 +162,13 @@
         "qs_pg:id":115532,
         "wd:id":"Q956031"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459010162,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"71884bbac8568ac36ea68e44933db338",
+    "wof:geomhash":"034b0a75aa949f68bd927d85c1876b8d",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -177,7 +178,7 @@
         }
     ],
     "wof:id":421203733,
-    "wof:lastmodified":1690867026,
+    "wof:lastmodified":1695886783,
     "wof:name":"Soyapango",
     "wof:parent_id":85677163,
     "wof:placetype":"county",

--- a/data/421/203/737/421203737.geojson
+++ b/data/421/203/737/421203737.geojson
@@ -168,6 +168,7 @@
         "hasc:id":"SV.SS.SN",
         "qs_pg:id":115533
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459010162,
     "wof:geom_alt":[
@@ -183,7 +184,7 @@
         }
     ],
     "wof:id":421203737,
-    "wof:lastmodified":1694492931,
+    "wof:lastmodified":1695886761,
     "wof:name":"San Martin",
     "wof:parent_id":85677163,
     "wof:placetype":"county",

--- a/data/421/203/739/421203739.geojson
+++ b/data/421/203/739/421203739.geojson
@@ -787,6 +787,7 @@
         "hasc:id":"SV.SO.AR",
         "qs_pg:id":115534
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459010162,
     "wof:geom_alt":[
@@ -802,7 +803,7 @@
         }
     ],
     "wof:id":421203739,
-    "wof:lastmodified":1694492498,
+    "wof:lastmodified":1695886783,
     "wof:name":"Armenia",
     "wof:parent_id":85677159,
     "wof:placetype":"county",

--- a/data/421/203/741/421203741.geojson
+++ b/data/421/203/741/421203741.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003279,
-    "geom:area_square_m":39401978.905087,
+    "geom:area_square_m":39402006.71546,
     "geom:bbox":"-89.129339,13.607221,-89.04141,13.682149",
     "geom:latitude":13.649665,
     "geom:longitude":-89.093991,
@@ -111,12 +111,13 @@
         "qs_pg:id":115535,
         "wd:id":"Q679112"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459010162,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"858f0410842e48a523922a3262d4942b",
+    "wof:geomhash":"becc185213c2675ca81e47578aa16d22",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":421203741,
-    "wof:lastmodified":1690867026,
+    "wof:lastmodified":1695886783,
     "wof:name":"Santiago Texacuangos",
     "wof:parent_id":85677163,
     "wof:placetype":"county",

--- a/data/421/203/743/421203743.geojson
+++ b/data/421/203/743/421203743.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005731,
-    "geom:area_square_m":68827999.280925,
+    "geom:area_square_m":68827873.786535,
     "geom:bbox":"-89.16182,13.713987,-89.082799,13.850085",
     "geom:latitude":13.783018,
     "geom:longitude":-89.118661,
@@ -123,12 +123,13 @@
         "qs_pg:id":115537,
         "wd:id":"Q1003568"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459010162,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"cacb68d53c5e09fb3003936882e7d684",
+    "wof:geomhash":"cb37ade67222768c05f536a98f845a8d",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":421203743,
-    "wof:lastmodified":1690867026,
+    "wof:lastmodified":1695886783,
     "wof:name":"Tonacatepeque",
     "wof:parent_id":85677163,
     "wof:placetype":"county",

--- a/data/421/203/745/421203745.geojson
+++ b/data/421/203/745/421203745.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.013943,
-    "geom:area_square_m":167195833.860838,
+    "geom:area_square_m":167196104.484522,
     "geom:bbox":"-89.593701,14.057876,-89.401001,14.182028",
     "geom:latitude":14.117635,
     "geom:longitude":-89.493234,
@@ -111,12 +111,13 @@
         "qs_pg:id":115538,
         "wd:id":"Q3985393"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459010162,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"03394c030e0f8774615459a50eee4803",
+    "wof:geomhash":"c599e19508252e444b35b837d509c71b",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":421203745,
-    "wof:lastmodified":1690867026,
+    "wof:lastmodified":1695886783,
     "wof:name":"Texistepeque",
     "wof:parent_id":85677195,
     "wof:placetype":"county",

--- a/data/421/203/747/421203747.geojson
+++ b/data/421/203/747/421203747.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009571,
-    "geom:area_square_m":115004357.394163,
+    "geom:area_square_m":115004518.434476,
     "geom:bbox":"-88.799576,13.618556,-88.605316,13.703022",
     "geom:latitude":13.660141,
     "geom:longitude":-88.696064,
@@ -111,12 +111,13 @@
         "qs_pg:id":115540,
         "wd:id":"Q617890"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459010162,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6f41699aeab4f997b629eb69c837cf0b",
+    "wof:geomhash":"a74915b88b9acd254d135e839b8a96ae",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":421203747,
-    "wof:lastmodified":1690867025,
+    "wof:lastmodified":1695886783,
     "wof:name":"Apastepeque",
     "wof:parent_id":85677185,
     "wof:placetype":"county",

--- a/data/421/203/751/421203751.geojson
+++ b/data/421/203/751/421203751.geojson
@@ -243,6 +243,7 @@
         "hasc:id":"SV.MO.SC",
         "qs_pg:id":115542
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459010162,
     "wof:geom_alt":[
@@ -258,7 +259,7 @@
         }
     ],
     "wof:id":421203751,
-    "wof:lastmodified":1694492931,
+    "wof:lastmodified":1695886761,
     "wof:name":"San Carlos",
     "wof:parent_id":85677173,
     "wof:placetype":"county",

--- a/data/421/204/283/421204283.geojson
+++ b/data/421/204/283/421204283.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01514,
-    "geom:area_square_m":181840794.467704,
+    "geom:area_square_m":181840808.547613,
     "geom:bbox":"-90.032055,13.664549,-89.838646,13.826514",
     "geom:latitude":13.748165,
     "geom:longitude":-89.936903,
@@ -111,12 +111,13 @@
         "qs_pg:id":238977,
         "wd:id":"Q2779408"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459010179,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d1df1982a37cd9d761bd6f4649e2612c",
+    "wof:geomhash":"abfd8168c480def0692fd6b0c8eae795",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":421204283,
-    "wof:lastmodified":1690867025,
+    "wof:lastmodified":1695886783,
     "wof:name":"Jujutla",
     "wof:parent_id":85677139,
     "wof:placetype":"county",

--- a/data/421/205/339/421205339.geojson
+++ b/data/421/205/339/421205339.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005682,
-    "geom:area_square_m":68229880.86622,
+    "geom:area_square_m":68229991.649875,
     "geom:bbox":"-89.761528,13.740276,-89.634403,13.860611",
     "geom:latitude":13.798837,
     "geom:longitude":-89.707805,
@@ -114,12 +114,13 @@
         "qs_pg:id":261859,
         "wd:id":"Q224791"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459010221,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c5fc3219708deba4e44c5942bc223c50",
+    "wof:geomhash":"f104d6605b9327290ebdda8e92744ad9",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":421205339,
-    "wof:lastmodified":1690867027,
+    "wof:lastmodified":1695886783,
     "wof:name":"Nahuizalco",
     "wof:parent_id":85677159,
     "wof:placetype":"county",

--- a/data/421/205/341/421205341.geojson
+++ b/data/421/205/341/421205341.geojson
@@ -83,6 +83,7 @@
         "hasc:id":"SV.US.US",
         "qs_pg:id":261860
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1459010221,
     "wof:geom_alt":[
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":421205341,
-    "wof:lastmodified":1694492796,
+    "wof:lastmodified":1695886502,
     "wof:name":"Usulutan",
     "wof:parent_id":85677187,
     "wof:placetype":"county",

--- a/data/856/325/45/85632545.geojson
+++ b/data/856/325/45/85632545.geojson
@@ -1146,6 +1146,7 @@
         "hasc:id":"SV",
         "icao:code":"YS",
         "ioc:id":"ESA",
+        "iso:code":"SV",
         "itu:id":"SLV",
         "loc:id":"n79066409",
         "m49:code":"222",
@@ -1160,6 +1161,7 @@
         "wk:page":"El Salvador",
         "wmo:id":"ES"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SV",
     "wof:country_alpha3":"SLV",
     "wof:geom_alt":[
@@ -1181,7 +1183,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1694639528,
+    "wof:lastmodified":1695881184,
     "wof:name":"El Salvador",
     "wof:parent_id":102191575,
     "wof:placetype":"country",

--- a/data/856/771/39/85677139.geojson
+++ b/data/856/771/39/85677139.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.099967,
-    "geom:area_square_m":1200117270.176957,
+    "geom:area_square_m":1200117127.756897,
     "geom:bbox":"-90.133533,13.664549,-89.694002,14.063456",
     "geom:latitude":13.859736,
     "geom:longitude":-89.90542,
@@ -310,17 +310,19 @@
         "gn:id":3587425,
         "gp:id":2345292,
         "hasc:id":"SV.AH",
+        "iso:code":"SV-AH",
         "iso:id":"SV-AH",
         "qs_pg:id":1083823,
         "unlc:id":"SV-AH",
         "wd:id":"Q572993",
         "wk:page":"Ahuachap\u00e1n Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SV",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c9e2c68419ca27ec21eb8e985fb59b9b",
+    "wof:geomhash":"5bcb25c2ed62c34edf4749465d6287f9",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -335,7 +337,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690867012,
+    "wof:lastmodified":1695884362,
     "wof:name":"Ahuachap\u00e1n",
     "wof:parent_id":85632545,
     "wof:placetype":"region",

--- a/data/856/771/41/85677141.geojson
+++ b/data/856/771/41/85677141.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.092016,
-    "geom:area_square_m":1104563782.873162,
+    "geom:area_square_m":1104563443.983272,
     "geom:bbox":"-88.989631,13.74,-88.491517,14.024463",
     "geom:latitude":13.88136,
     "geom:longitude":-88.711305,
@@ -310,17 +310,19 @@
         "gn:id":3587217,
         "gp:id":2345293,
         "hasc:id":"SV.CA",
+        "iso:code":"SV-CA",
         "iso:id":"SV-CA",
         "qs_pg:id":1097024,
         "unlc:id":"SV-CA",
         "wd:id":"Q914058",
         "wk:page":"Caba\u00f1as Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SV",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5d18af042082be8eebd237a9d2a271c3",
+    "wof:geomhash":"49d6a820976e19ec57d29ec91a9f14ca",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -335,7 +337,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690867013,
+    "wof:lastmodified":1695884362,
     "wof:name":"Caba\u00f1as",
     "wof:parent_id":85632545,
     "wof:placetype":"region",

--- a/data/856/771/45/85677145.geojson
+++ b/data/856/771/45/85677145.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.062215,
-    "geom:area_square_m":746948413.052524,
+    "geom:area_square_m":746948444.376912,
     "geom:bbox":"-89.169009,13.640652,-88.858063,14.076171",
     "geom:latitude":13.846235,
     "geom:longitude":-89.022632,
@@ -306,17 +306,19 @@
         "gn:id":3586831,
         "gp:id":2345295,
         "hasc:id":"SV.CU",
+        "iso:code":"SV-CU",
         "iso:id":"SV-CU",
         "qs_pg:id":894881,
         "unlc:id":"SV-CU",
         "wd:id":"Q1130677",
         "wk:page":"Cuscatl\u00e1n Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SV",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"eaefcd54dcc050a744f28315aa9282e6",
+    "wof:geomhash":"b886dad251a02609d989980998e922d6",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -331,7 +333,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690867011,
+    "wof:lastmodified":1695884362,
     "wof:name":"Cuscatl\u00e1n",
     "wof:parent_id":85632545,
     "wof:placetype":"region",

--- a/data/856/771/51/85677151.geojson
+++ b/data/856/771/51/85677151.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.138069,
-    "geom:area_square_m":1658634338.693977,
+    "geom:area_square_m":1658634265.351855,
     "geom:bbox":"-89.629423,13.41705,-89.135299,14.064911",
     "geom:latitude":13.704795,
     "geom:longitude":-89.36528,
@@ -310,17 +310,19 @@
         "gn:id":3585155,
         "gp:id":2345296,
         "hasc:id":"SV.LI",
+        "iso:code":"SV-LI",
         "iso:id":"SV-LI",
         "qs_pg:id":1046582,
         "unlc:id":"SV-LI",
         "wd:id":"Q930820",
         "wk:page":"La Libertad Department (El Salvador)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SV",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"661e96826dcdf2c6559598e145182958",
+    "wof:geomhash":"dcd4b9f0e873696ecef532f543aa1634",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -335,7 +337,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690867010,
+    "wof:lastmodified":1695884871,
     "wof:name":"La Libertad",
     "wof:parent_id":85632545,
     "wof:placetype":"region",

--- a/data/856/771/55/85677155.geojson
+++ b/data/856/771/55/85677155.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.10156,
-    "geom:area_square_m":1221216730.330388,
+    "geom:area_square_m":1221216875.15162,
     "geom:bbox":"-89.163139,13.267469,-88.78,13.669931",
     "geom:latitude":13.479101,
     "geom:longitude":-88.967304,
@@ -316,17 +316,19 @@
         "gn:id":3585087,
         "gp:id":2345297,
         "hasc:id":"SV.PA",
+        "iso:code":"SV-PA",
         "iso:id":"SV-PA",
         "qs_pg:id":894882,
         "unlc:id":"SV-PA",
         "wd:id":"Q1129788",
         "wk:page":"La Paz Department (El Salvador)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SV",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3a9887a47889f35ebb16a8a85424cecd",
+    "wof:geomhash":"d65d24822f2a8d45ba34bcc9e1512dce",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -341,7 +343,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690867012,
+    "wof:lastmodified":1695884871,
     "wof:name":"La Paz",
     "wof:parent_id":85632545,
     "wof:placetype":"region",

--- a/data/856/771/59/85677159.geojson
+++ b/data/856/771/59/85677159.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.104154,
-    "geom:area_square_m":1251260604.324116,
+    "geom:area_square_m":1251261082.510292,
     "geom:bbox":"-89.954641,13.518961,-89.43703,13.905039",
     "geom:latitude":13.696039,
     "geom:longitude":-89.687747,
@@ -280,17 +280,19 @@
         "gn:id":3583101,
         "gp:id":2345304,
         "hasc:id":"SV.SO",
+        "iso:code":"SV-SO",
         "iso:id":"SV-SO",
         "qs_pg:id":235593,
         "unlc:id":"SV-SO",
         "wd:id":"Q212540",
         "wk:page":"Sonsonate Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SV",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5f30489e266b9849335177afbb7abbf6",
+    "wof:geomhash":"63d234c82e3c9f1037e68f0450b567d2",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -305,7 +307,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690867010,
+    "wof:lastmodified":1695884871,
     "wof:name":"Sonsonate",
     "wof:parent_id":85632545,
     "wof:placetype":"region",

--- a/data/856/771/63/85677163.geojson
+++ b/data/856/771/63/85677163.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.075326,
-    "geom:area_square_m":904640783.947221,
+    "geom:area_square_m":904640464.097543,
     "geom:bbox":"-89.292423,13.472606,-89.025382,14.061273",
     "geom:latitude":13.771569,
     "geom:longitude":-89.172788,
@@ -313,16 +313,18 @@
         "gn:id":3583360,
         "gp:id":2345301,
         "hasc:id":"SV.SS",
+        "iso:code":"SV-SS",
         "iso:id":"SV-SS",
         "qs_pg:id":235592,
         "wd:id":"Q1543219",
         "wk:page":"San Salvador Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SV",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9e6ecde34e73db039db4215f14752949",
+    "wof:geomhash":"09a0c373d8f5fc485529bbf793e4bf0f",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -337,7 +339,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690867012,
+    "wof:lastmodified":1695884871,
     "wof:name":"San Salvador",
     "wof:parent_id":85632545,
     "wof:placetype":"region",

--- a/data/856/771/69/85677169.geojson
+++ b/data/856/771/69/85677169.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.165348,
-    "geom:area_square_m":1987864416.848769,
+    "geom:area_square_m":1987865057.818194,
     "geom:bbox":"-88.092368,13.154139,-87.68158,13.922105",
     "geom:latitude":13.52251,
     "geom:longitude":-87.887384,
@@ -252,17 +252,19 @@
         "gn:id":3584767,
         "gp:id":2345298,
         "hasc:id":"SV.UN",
+        "iso:code":"SV-UN",
         "iso:id":"SV-UN",
         "qs_pg:id":1083827,
         "unlc:id":"SV-UN",
         "wd:id":"Q1130688",
         "wk:page":"La Uni\u00f3n Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SV",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d4cddd483e2170664ea540c51df1e283",
+    "wof:geomhash":"f5a2531cefb692aced27e47f430552e4",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -277,7 +279,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690867010,
+    "wof:lastmodified":1695884362,
     "wof:name":"La Uni\u00f3n",
     "wof:parent_id":85632545,
     "wof:placetype":"region",

--- a/data/856/771/73/85677173.geojson
+++ b/data/856/771/73/85677173.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.110456,
-    "geom:area_square_m":1326525605.032624,
+    "geom:area_square_m":1326525672.777783,
     "geom:bbox":"-88.274908,13.547404,-87.929259,13.999649",
     "geom:latitude":13.77567,
     "geom:longitude":-88.105214,
@@ -304,17 +304,19 @@
         "gn:id":3584317,
         "gp:id":2345299,
         "hasc:id":"SV.MO",
+        "iso:code":"SV-MO",
         "iso:id":"SV-MO",
         "qs_pg:id":894883,
         "unlc:id":"SV-MO",
         "wd:id":"Q1122836",
         "wk:page":"Moraz\u00e1n Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SV",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7718718fa7b0a25bfa97aad762b1bd4f",
+    "wof:geomhash":"bfe4e61d6d52b9908b236c2e83134e7c",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -329,7 +331,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690867011,
+    "wof:lastmodified":1695884362,
     "wof:name":"Moraz\u00e1n",
     "wof:parent_id":85632545,
     "wof:placetype":"region",

--- a/data/856/771/77/85677177.geojson
+++ b/data/856/771/77/85677177.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.177662,
-    "geom:area_square_m":2135743278.503851,
+    "geom:area_square_m":2135743676.077911,
     "geom:bbox":"-88.530006,13.166222,-88.017592,13.915584",
     "geom:latitude":13.541518,
     "geom:longitude":-88.255211,
@@ -311,17 +311,19 @@
         "gn:id":3583462,
         "gp:id":2345300,
         "hasc:id":"SV.SM",
+        "iso:code":"SV-SM",
         "iso:id":"SV-SM",
         "qs_pg:id":235591,
         "unlc:id":"SV-SM",
         "wd:id":"Q930804",
         "wk:page":"San Miguel Department (El Salvador)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SV",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b93abcaf1fc652abd103081df6b5c701",
+    "wof:geomhash":"35e81c2b6be8cc8f0b20c91c7d3890f3",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -336,7 +338,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690867013,
+    "wof:lastmodified":1695884871,
     "wof:name":"San Miguel",
     "wof:parent_id":85632545,
     "wof:placetype":"region",

--- a/data/856/771/85/85677185.geojson
+++ b/data/856/771/85/85677185.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.100131,
-    "geom:area_square_m":1203382589.330093,
+    "geom:area_square_m":1203382452.496704,
     "geom:bbox":"-88.898901,13.244638,-88.485578,13.798114",
     "geom:latitude":13.607991,
     "geom:longitude":-88.722,
@@ -305,17 +305,19 @@
         "gn:id":3583176,
         "gp:id":2345303,
         "hasc:id":"SV.SV",
+        "iso:code":"SV-SV",
         "iso:id":"SV-SV",
         "qs_pg:id":318465,
         "unlc:id":"SV-SV",
         "wd:id":"Q1130180",
         "wk:page":"San Vicente Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SV",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b0d5252158d321f3c524b86663a251f0",
+    "wof:geomhash":"138993d74fc1f0abc5f2db5dc3a3a69a",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -330,7 +332,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690867013,
+    "wof:lastmodified":1695884871,
     "wof:name":"San Vicente",
     "wof:parent_id":85632545,
     "wof:placetype":"region",

--- a/data/856/771/87/85677187.geojson
+++ b/data/856/771/87/85677187.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.169126,
-    "geom:area_square_m":2034506306.872792,
+    "geom:area_square_m":2034505549.347108,
     "geom:bbox":"-88.813218,13.157444,-88.124637,13.700306",
     "geom:latitude":13.38041,
     "geom:longitude":-88.494734,
@@ -305,17 +305,19 @@
         "gn:id":3582882,
         "gp:id":2345305,
         "hasc:id":"SV.US",
+        "iso:code":"SV-US",
         "iso:id":"SV-US",
         "qs_pg:id":1135033,
         "unlc:id":"SV-US",
         "wd:id":"Q1122748",
         "wk:page":"Usulut\u00e1n Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SV",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"444840cf465039dfd430333e54f39706",
+    "wof:geomhash":"9b79699667a420d8a99ccd8bf14d0456",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -330,7 +332,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690867012,
+    "wof:lastmodified":1695884362,
     "wof:name":"Usulut\u00e1n",
     "wof:parent_id":85632545,
     "wof:placetype":"region",

--- a/data/856/771/93/85677193.geojson
+++ b/data/856/771/93/85677193.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.166267,
-    "geom:area_square_m":1993583507.210886,
+    "geom:area_square_m":1993584318.870265,
     "geom:bbox":"-89.432884,13.93293,-88.681478,14.415878",
     "geom:latitude":14.145371,
     "geom:longitude":-89.076674,
@@ -262,17 +262,19 @@
         "gn:id":3587090,
         "gp:id":2345294,
         "hasc:id":"SV.CH",
+        "iso:code":"SV-CH",
         "iso:id":"SV-CH",
         "qs_pg:id":1083826,
         "unlc:id":"SV-CH",
         "wd:id":"Q522221",
         "wk:page":"Chalatenango Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SV",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d9f14397cb9eefd65d469e0b7beec63a",
+    "wof:geomhash":"37cd48cc90bef19bf2925e3138fc4a1c",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -287,7 +289,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690867011,
+    "wof:lastmodified":1695884871,
     "wof:name":"Chalatenango",
     "wof:parent_id":85632545,
     "wof:placetype":"region",

--- a/data/856/771/95/85677195.geojson
+++ b/data/856/771/95/85677195.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.170456,
-    "geom:area_square_m":2043995043.265517,
+    "geom:area_square_m":2043994479.274752,
     "geom:bbox":"-89.746039,13.781807,-89.247718,14.450557",
     "geom:latitude":14.124303,
     "geom:longitude":-89.508456,
@@ -303,17 +303,19 @@
         "gn:id":3583332,
         "gp:id":2345302,
         "hasc:id":"SV.SA",
+        "iso:code":"SV-SA",
         "iso:id":"SV-SA",
         "qs_pg:id":423765,
         "unlc:id":"SV-SA",
         "wd:id":"Q671158",
         "wk:page":"Santa Ana Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SV",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"df885f193994c483b29dae7cad72a58b",
+    "wof:geomhash":"e3a6fc2dc56663b9e28e368940becfec",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -328,7 +330,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690867009,
+    "wof:lastmodified":1695884871,
     "wof:name":"Santa Ana",
     "wof:parent_id":85632545,
     "wof:placetype":"region",

--- a/data/890/451/505/890451505.geojson
+++ b/data/890/451/505/890451505.geojson
@@ -84,6 +84,7 @@
         "hasc:id":"SV.PA.SH",
         "qs_pg:id":467268
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1469052782,
     "wof:geom_alt":[
@@ -99,7 +100,7 @@
         }
     ],
     "wof:id":890451505,
-    "wof:lastmodified":1694492498,
+    "wof:lastmodified":1695886784,
     "wof:name":"San Luis La Herradura",
     "wof:parent_id":85677155,
     "wof:placetype":"county",

--- a/data/890/452/037/890452037.geojson
+++ b/data/890/452/037/890452037.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003594,
-    "geom:area_square_m":43196058.055698,
+    "geom:area_square_m":43196383.114088,
     "geom:bbox":"-88.44636,13.53361,-88.375417,13.666201",
     "geom:latitude":13.608681,
     "geom:longitude":-88.409872,
@@ -111,12 +111,13 @@
         "wd:id":"Q164920",
         "wk:page":"Puerto El Triunfo"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SV",
     "wof:created":1469052802,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0d1d204b5c60470a8aa1474ccb806ca1",
+    "wof:geomhash":"6b4ebd35ddb039e888f780f31e9aaa36",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":890452037,
-    "wof:lastmodified":1690867056,
+    "wof:lastmodified":1695886784,
     "wof:name":"El Triunfo",
     "wof:parent_id":85677187,
     "wof:placetype":"county",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.